### PR TITLE
Aida 229

### DIFF
--- a/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
+++ b/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
@@ -452,7 +452,6 @@ public class ExamplesAndValidationTest {
     }
 
     @Test
-    @Disabled
     void nonTypeUsedAsType() {
       final Model model = createModel();
 
@@ -464,7 +463,6 @@ public class ExamplesAndValidationTest {
       markType(model, "http://www.test.edu/typeAssertion/1", entity,
           // use a blank node as the bogus entity type
           model.createResource(), system, 1.0);
-      RDFDataMgr.write(System.out, model, RDFFormat.TURTLE_PRETTY);
       assertFalse(validator.validateKB(model));
     }
 


### PR DESCRIPTION
This is a fix for https://github.com/NextCenturyCorporation/AIDA-Interchange-Format/issues/6

It simply renames the output bin from coldstart2Gaia to coldstart2AidaInterchange to match the readme.