### PR TITLE
Aida 264 (#36)

### DIFF
--- a/src/main/java/edu/isi/gaia/AidaAnnotationOntology.kt
+++ b/src/main/java/edu/isi/gaia/AidaAnnotationOntology.kt
@@ -95,6 +95,8 @@ object AidaAnnotationOntology {
     @JvmField
     val EVENT_CLASS = ResourceFactory.createResource(NAMESPACE + "Event")!!
     @JvmField
+    val RELATION_CLASS = ResourceFactory.createResource(NAMESPACE + "Relation")!!
+    @JvmField
     val CONFIDENCE_CLASS = ResourceFactory.createResource(NAMESPACE + "Confidence")!!
     @JvmField
     val TEXT_JUSTIFICATION_CLASS =

--- a/src/main/resources/edu/isi/gaia/aida-domain-common.ttl
+++ b/src/main/resources/edu/isi/gaia/aida-domain-common.ttl
@@ -31,3 +31,5 @@
 :RelationType a owl:Class ;
    rdfs:label "AIDA relation type" .
 
+:RelationArgumentType a owl:Class ;
+   rdfs:label "AIDA relation argument type" .

--- a/src/main/resources/edu/isi/gaia/aida_ontology.shacl
+++ b/src/main/resources/edu/isi/gaia/aida_ontology.shacl
@@ -306,7 +306,7 @@ aida:EventSubclass
         sh:minCount 1 ] ] )
   .
 
-# Allow for subclasses as well as instances of EventType
+# Allow for subclasses as well as instances of RelationType
 aida:RelationSubclass
   a sh:NodeShape ;
   sh:xone (
@@ -325,6 +325,17 @@ aida:EventArgumentSubclass
       [sh:property [
           sh:path rdfs:subClassOf ;
           sh:hasValue aidaDomainCommon:EventArgumentType ;
+          sh:minCount 1 ] ] )
+    .
+
+# Allow for subclasses as well as instances of RelationArgumentType
+aida:RelationArgumentSubclass
+  a sh:NodeShape ;
+    sh:xone (
+      [sh:class aidaDomainCommon:RelationArgumentType ]
+      [sh:property [
+          sh:path rdfs:subClassOf ;
+          sh:hasValue aidaDomainCommon:RelationArgumentType ;
           sh:minCount 1 ] ] )
     .
 
@@ -355,6 +366,7 @@ aida:TypeShape
    sh:property [
      sh:path rdf:subject ;
      sh:xone ( [sh:class aida:Entity ]
+               [sh:class aida:Relation ]
                [sh:class aida:Event ] ) ;
      sh:message "Subject of type assertion must be entity or event"];
 
@@ -363,6 +375,7 @@ aida:TypeShape
    sh:property [
      sh:path rdf:object ;
      sh:xone ( [sh:node aida:EntitySubclass ]
+               [sh:node aida:RelationSubclass ]
                [sh:node aida:EventSubclass ] ) ;
      sh:message "Object of type assertion must be an entity or event type"];
     # TODO: handle temporal or string values
@@ -746,7 +759,7 @@ aida:RdfStatementShape
      sh:xone (
          [ sh:hasValue rdf:type ]
          [ sh:node aida:EventArgumentSubclass ]
-         [ sh:node aida:RelationSubclass ]) ;
+         [ sh:node aida:RelationArgumentSubclass ]) ;
       sh:message "All rdf:statements must be type declarations or have predicates from the domain relation or event argument types. This error is often caused by using a value outside the domain ontology"
      ]
   .

--- a/src/main/resources/edu/isi/gaia/interchange-ontology.ttl
+++ b/src/main/resources/edu/isi/gaia/interchange-ontology.ttl
@@ -28,6 +28,10 @@
    rdfs:label "Event" ;
    rdfs:definition "An event in an AIDA KB" .
 
+:Relation a owl:Class ;
+   rdfs:label "Relation" ;
+   rdfs:definition "An relation in an AIDA KB" .
+
 :SameAsCluster a owl:Class ;
    rdfs:label "Same-As Cluster";
    rdfs:definition "Represents a collection of events or entities which may in fact be the same".

--- a/src/main/resources/edu/isi/gaia/seedling-ontology.ttl
+++ b/src/main/resources/edu/isi/gaia/seedling-ontology.ttl
@@ -1,5 +1,5 @@
 ######################################################
-# Created by LDCOntology.java on 2018-07-16T13:26:56.470Z
+# Created by LDCOntology.java on 2018-07-18T20:38:31.788Z
 ######################################################
 @prefix schema: <http://schema.org/> .
 @prefix ldcOnt: <http://darpa.mil/ontologies/SeedlingOntology#> .
@@ -12,7 +12,7 @@
 @prefix ldc:   <http://darpa.mil/annotations/ldc#> .
 
 <http://darpa.mil/ontologies/SeedlingOntology>
-        a               owl:Ontology ;
+        a                owl:Ontology ;
         rdfs:comment     "An ontology for creating messages from LDC data to use in AIDA interchange language development" ;
         rdfs:label       "AIDA Domain Ontology for LDC Seedling Corpus" ;
         owl:versionInfo  "Version 0.1" .
@@ -188,6 +188,310 @@ ldcOnt:phys_orglocorig
 ldcOnt:phys_resident  a  owl:Class ;
         rdfs:label       "Physical_Resident" ;
         rdfs:subClassOf  aidaDomainCommon:RelationType .
+
+######################################################
+# Relation argument types
+######################################################
+ldcOnt:genafl_apora_affiliate
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_apora ;
+        rdfs:label            "Affiliate" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Weapon , ldcOnt:Vehicle , ldcOnt:Facility , ldcOnt:Commodity .
+
+ldcOnt:genafl_apora_affiliation
+        a                     owl:ObjectProperty , owl:Class ;
+        rdfs:domain           ldcOnt:genafl_apora ;
+        rdfs:label            "Affiliation" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization , ldcOnt:Location , ldcOnt:Person , ldcOnt:GeopoliticalEntity , ldcOnt:Sides .
+
+ldcOnt:genafl_more_affiliation
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_more ;
+        rdfs:label            "Affiliation" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Location , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:genafl_more_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_more ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:genafl_opra_affiliation
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_opra ;
+        rdfs:label            "Affiliation" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization .
+
+ldcOnt:genafl_opra_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_opra ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:genafl_orgweb_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_orgweb ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:genafl_orgweb_website
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_orgweb ;
+        rdfs:label            "Website" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:URL .
+
+ldcOnt:genafl_perage_age
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_perage ;
+        rdfs:label            "Age" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Age .
+
+ldcOnt:genafl_perage_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_perage ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:genafl_spon_entity
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_spon ;
+        rdfs:label            "Entity" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization , ldcOnt:Location , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:genafl_spon_sponsor
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:genafl_spon ;
+        rdfs:label            "Sponsor" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Organization , ldcOnt:Location , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:measurement_count_count
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:measurement_count ;
+        rdfs:label            "Count" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:NumericalValue .
+
+ldcOnt:measurement_count_item
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:measurement_count ;
+        rdfs:label            "Item" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:Weapon , ldcOnt:GeopoliticalEntity , ldcOnt:Organization , ldcOnt:Commodity , ldcOnt:Person , ldcOnt:Vehicle , ldcOnt:Ballot , ldcOnt:Facility .
+
+ldcOnt:orgafl_empmem_employee
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_empmem ;
+        rdfs:label            "Employee" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:orgafl_empmem_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_empmem ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:orgafl_found_founder
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_found ;
+        rdfs:label            "Founder" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:orgafl_found_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_found ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:orgafl_invshar_investorshareholder
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_invshar ;
+        rdfs:label            "InvestorShareholder" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:orgafl_invshar_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_invshar ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:orgafl_lead_leader
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_lead ;
+        rdfs:label            "Leader" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:orgafl_lead_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_lead ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:orgafl_own_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_own ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:orgafl_own_owner
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_own ;
+        rdfs:label            "Owner" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:orgafl_stualm_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_stualm ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:orgafl_stualm_studentalum
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:orgafl_stualm ;
+        rdfs:label            "StudentAlum" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:partwhole_membership_member
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:partwhole_membership ;
+        rdfs:label            "Member" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:partwhole_membership_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:partwhole_membership ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:partwhole_subsid_parent
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:partwhole_subsid ;
+        rdfs:label            "Parent" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:partwhole_subsid_subsidiary
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:partwhole_subsid ;
+        rdfs:label            "Subsidiary" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:persoc_bus_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:persoc_bus ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:persoc_fam_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:persoc_fam ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:persoc_role_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:persoc_role ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:persoc_role_title
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:persoc_role ;
+        rdfs:label            "Title" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Title .
+
+ldcOnt:persoc_unspc_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:persoc_unspc ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:phys_locnear_entity
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_locnear ;
+        rdfs:label            "Entity" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Commodity , ldcOnt:Vehicle , ldcOnt:Person , ldcOnt:Weapon , ldcOnt:Facility .
+
+ldcOnt:phys_locnear_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_locnear ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:phys_orghq_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_orghq ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:phys_orghq_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_orghq ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:phys_orglocorig_organization
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_orglocorig ;
+        rdfs:label            "Organization" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:phys_orglocorig_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_orglocorig ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:phys_resident_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_resident ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:phys_resident_resident
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:phys_resident ;
+        rdfs:label            "Resident" ;
+        rdfs:subClassOf       aidaDomainCommon:RelationArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
 
 ######################################################
 # Event types
@@ -612,220 +916,220 @@ ldcOnt:contact_meet_time
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:existence_damage-destroy_tbd1
+ldcOnt:existence_damage-destroy_agent
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:EXISTENCE_DAMAGE-DESTROY ;
-        rdfs:label            "TBD1" ;
+        rdfs:label            "Agent" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
 
-ldcOnt:existence_damage-destroy_tbd2
+ldcOnt:existence_damage-destroy_instrument
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:EXISTENCE_DAMAGE-DESTROY ;
-        rdfs:label            "TBD2" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Vehicle , ldcOnt:Commodity , ldcOnt:Facility , ldcOnt:Ballot , ldcOnt:Weapon .
-
-ldcOnt:existence_damage-destroy_tbd3
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:EXISTENCE_DAMAGE-DESTROY ;
-        rdfs:label            "TBD3" ;
+        rdfs:label            "Instrument" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Weapon , ldcOnt:Vehicle , ldcOnt:Commodity .
 
-ldcOnt:existence_damage-destroy_tbd4
+ldcOnt:existence_damage-destroy_place
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:EXISTENCE_DAMAGE-DESTROY ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Place" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:existence_damage-destroy_tbd5
+ldcOnt:existence_damage-destroy_time
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:EXISTENCE_DAMAGE-DESTROY ;
-        rdfs:label            "TBD5" ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:government_agreements_tbd1
+ldcOnt:existence_damage-destroy_victim
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:EXISTENCE_DAMAGE-DESTROY ;
+        rdfs:label            "Victim" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Commodity , ldcOnt:Facility , ldcOnt:Weapon , ldcOnt:Ballot , ldcOnt:Vehicle .
+
+ldcOnt:government_agreements_place
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_AGREEMENTS ;
-        rdfs:label            "TBD1" ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:government_agreements_signer
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:GOVERNMENT_AGREEMENTS ;
+        rdfs:label            "Signer" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Sides , ldcOnt:GeopoliticalEntity .
 
-ldcOnt:government_agreements_tbd2
+ldcOnt:government_agreements_time
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_AGREEMENTS ;
-        rdfs:label            "TBD2" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
-
-ldcOnt:government_agreements_tbd3
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:GOVERNMENT_AGREEMENTS ;
-        rdfs:label            "TBD3" ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:government_legislate_tbd1
+ldcOnt:government_legislate_law
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_LEGISLATE ;
-        rdfs:label            "TBD1" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Organization .
-
-ldcOnt:government_legislate_tbd2
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:GOVERNMENT_LEGISLATE ;
-        rdfs:label            "TBD2" ;
+        rdfs:label            "Law" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Law .
 
-ldcOnt:government_legislate_tbd3
+ldcOnt:government_legislate_legislature
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_LEGISLATE ;
-        rdfs:label            "TBD3" ;
+        rdfs:label            "Legislature" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Organization .
+
+ldcOnt:government_legislate_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:GOVERNMENT_LEGISLATE ;
+        rdfs:label            "Place" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:government_legislate_tbd4
+ldcOnt:government_legislate_time
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_LEGISLATE ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:government_spy_tbd1
+ldcOnt:government_spy_agent
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_SPY ;
-        rdfs:label            "TBD1" ;
+        rdfs:label            "Agent" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Person .
 
-ldcOnt:government_spy_tbd2
+ldcOnt:government_spy_beneficiary
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_SPY ;
-        rdfs:label            "TBD2" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
-
-ldcOnt:government_spy_tbd3
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:GOVERNMENT_SPY ;
-        rdfs:label            "TBD3" ;
+        rdfs:label            "Beneficiary" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
 
-ldcOnt:government_spy_tbd4
+ldcOnt:government_spy_place
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_SPY ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Place" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:government_spy_tbd5
+ldcOnt:government_spy_target
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_SPY ;
-        rdfs:label            "TBD5" ;
+        rdfs:label            "Target" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:government_spy_time
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:GOVERNMENT_SPY ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:government_vote_tbd1
+ldcOnt:government_vote_ballot
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
-        rdfs:label            "TBD1" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Person .
-
-ldcOnt:government_vote_tbd2
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
-        rdfs:label            "TBD2" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:Law .
-
-ldcOnt:government_vote_tbd3
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
-        rdfs:label            "TBD3" ;
+        rdfs:label            "Ballot" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Ballot .
 
-ldcOnt:government_vote_tbd4
+ldcOnt:government_vote_candidate
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Candidate" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:Law .
+
+ldcOnt:government_vote_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:government_vote_results
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
+        rdfs:label            "Results" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Results .
 
-ldcOnt:government_vote_tbd5
+ldcOnt:government_vote_time
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
-        rdfs:label            "TBD5" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
-
-ldcOnt:government_vote_tbd6
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
-        rdfs:label            "TBD6" ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:inspection_artifact_tbd1
+ldcOnt:government_vote_voter
         a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
-        rdfs:label            "TBD1" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
-
-ldcOnt:inspection_artifact_tbd2
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
-        rdfs:label            "TBD2" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Commodity , ldcOnt:Ballot , ldcOnt:Vehicle , ldcOnt:Facility , ldcOnt:Weapon .
-
-ldcOnt:inspection_artifact_tbd3
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
-        rdfs:label            "TBD3" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
-
-ldcOnt:inspection_artifact_tbd4
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
-        rdfs:label            "TBD4" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Time .
-
-ldcOnt:inspection_people_tbd1
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
-        rdfs:label            "TBD1" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
-
-ldcOnt:inspection_people_tbd2
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
-        rdfs:label            "TBD2" ;
+        rdfs:domain           ldcOnt:GOVERNMENT_VOTE ;
+        rdfs:label            "Voter" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Person .
 
-ldcOnt:inspection_people_tbd3
+ldcOnt:inspection_artifact_inspector
         a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
-        rdfs:label            "TBD3" ;
+        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
+        rdfs:label            "Inspector" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:inspection_artifact_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
+        rdfs:label            "Place" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:inspection_people_tbd4
+ldcOnt:inspection_artifact_thing
+        a                     owl:ObjectProperty , owl:Class ;
+        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
+        rdfs:label            "Thing" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Vehicle , ldcOnt:Weapon , ldcOnt:Commodity , ldcOnt:Ballot , ldcOnt:Facility .
+
+ldcOnt:inspection_artifact_time
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:INSPECTION_ARTIFACT ;
+        rdfs:label            "Time" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Time .
+
+ldcOnt:inspection_people_inspector
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Inspector" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:inspection_people_person
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
+        rdfs:label            "Person" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Person .
+
+ldcOnt:inspection_people_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
+        rdfs:label            "Place" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
+
+ldcOnt:inspection_people_time
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:INSPECTION_PEOPLE ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
@@ -1137,38 +1441,38 @@ ldcOnt:justice_fine_time
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:justice_investigate_tbd1
+ldcOnt:justice_investigate_crime
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
-        rdfs:label            "TBD1" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
-
-ldcOnt:justice_investigate_tbd2
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
-        rdfs:label            "TBD2" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
-
-ldcOnt:justice_investigate_tbd3
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
-        rdfs:label            "TBD3" ;
+        rdfs:label            "Crime" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Crime .
 
-ldcOnt:justice_investigate_tbd4
+ldcOnt:justice_investigate_investigatee
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Investigatee" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:justice_investigate_investigator
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
+        rdfs:label            "Investigator" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:justice_investigate_place
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
+        rdfs:label            "Place" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:justice_investigate_tbd5
+ldcOnt:justice_investigate_time
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:JUSTICE_INVESTIGATE ;
-        rdfs:label            "TBD5" ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
@@ -1766,45 +2070,45 @@ ldcOnt:transaction_transaction_time
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 
-ldcOnt:transaction_transfer-control_tbd1
+ldcOnt:transaction_transfer-control_beneficiary
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
-        rdfs:label            "TBD1" ;
+        rdfs:label            "Beneficiary" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
 
-ldcOnt:transaction_transfer-control_tbd2
+ldcOnt:transaction_transfer-control_giver
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
-        rdfs:label            "TBD2" ;
+        rdfs:label            "Giver" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
 
-ldcOnt:transaction_transfer-control_tbd3
+ldcOnt:transaction_transfer-control_place
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
-        rdfs:label            "TBD3" ;
-        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
-        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
-
-ldcOnt:transaction_transfer-control_tbd4
-        a                     owl:Class , owl:ObjectProperty ;
-        rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
-        rdfs:label            "TBD4" ;
+        rdfs:label            "Place" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:transaction_transfer-control_tbd5
+ldcOnt:transaction_transfer-control_recipient
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
-        rdfs:label            "TBD5" ;
+        rdfs:label            "Recipient" ;
+        rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
+        schema:rangeIncludes  ldcOnt:Sides , ldcOnt:Person , ldcOnt:Organization , ldcOnt:GeopoliticalEntity .
+
+ldcOnt:transaction_transfer-control_territory
+        a                     owl:Class , owl:ObjectProperty ;
+        rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
+        rdfs:label            "Territory" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Location , ldcOnt:GeopoliticalEntity , ldcOnt:Facility .
 
-ldcOnt:transaction_transfer-control_tbd6
+ldcOnt:transaction_transfer-control_time
         a                     owl:Class , owl:ObjectProperty ;
         rdfs:domain           ldcOnt:TRANSACTION_TRANSFER-CONTROL ;
-        rdfs:label            "TBD6" ;
+        rdfs:label            "Time" ;
         rdfs:subClassOf       aidaDomainCommon:EventArgumentType ;
         schema:rangeIncludes  ldcOnt:Time .
 

--- a/src/main/resources/edu/isi/gaia/seedling-owl-ontology.ttl
+++ b/src/main/resources/edu/isi/gaia/seedling-owl-ontology.ttl
@@ -1,5 +1,5 @@
 ######################################################
-# Created by LDCOntology.java on 2018-07-16T13:26:56.449Z
+# Created by LDCOntology.java on 2018-07-18T20:38:31.687Z
 ######################################################
 @prefix schema: <http://schema.org/> .
 @prefix ldcOnt: <http://darpa.mil/ontologies/SeedlingOntology#> .
@@ -12,7 +12,7 @@
 @prefix ldc:   <http://darpa.mil/annotations/ldc#> .
 
 <http://darpa.mil/ontologies/SeedlingOntology>
-        a               owl:Ontology ;
+        a                owl:Ontology ;
         rdfs:comment     "An ontology for creating messages from LDC data to use in AIDA interchange language development" ;
         rdfs:label       "AIDA Domain Ontology for LDC Seedling Corpus" ;
         owl:versionInfo  "Version 0.1" .
@@ -94,100 +94,422 @@ ldcOnt:Weapon  a         owl:Class ;
 ######################################################
 ldcOnt:genafl_apora  a   owl:Class ;
         rdfs:label       "General-Affiliation_Artifact-Political-Organization-Religious-Affiliation (APORA)" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Affiliation" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Location ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_apora_affiliation
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Affiliate" ;
+                                                owl:unionOf  ( ldcOnt:Commodity ldcOnt:Facility ldcOnt:Vehicle ldcOnt:Weapon )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_apora_affiliate
+                         ] .
 
 ldcOnt:genafl_more  a    owl:Class ;
         rdfs:label       "General-Affiliation_Person-Member-Origin-Religion-Ethnicity (MORE)" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Affiliation" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Location ldcOnt:Person ldcOnt:Sides )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_more_affiliation
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_more_person
+                         ] .
 
 ldcOnt:genafl_opra  a    owl:Class ;
         rdfs:label       "General-Affiliation_Organization-Political-Religious-Affiliation (OPRA)" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Affiliation" ;
+                                                owl:unionOf  ( ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_opra_affiliation
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_opra_organization
+                         ] .
 
 ldcOnt:genafl_orgweb  a  owl:Class ;
         rdfs:label       "General-Affiliation_Organization-Website" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Website" ;
+                                                owl:unionOf  ( ldcOnt:URL )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_orgweb_website
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_orgweb_organization
+                         ] .
 
 ldcOnt:genafl_perage  a  owl:Class ;
         rdfs:label       "General-Affiliation_Person-Age" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Age" ;
+                                                owl:unionOf  ( ldcOnt:Age )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_perage_age
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_perage_person
+                         ] .
 
 ldcOnt:genafl_spon  a    owl:Class ;
         rdfs:label       "General-Affiliation_Sponsorship" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Sponsor" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Location ldcOnt:Organization ldcOnt:Sides )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_spon_sponsor
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Entity" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Location ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:genafl_spon_entity
+                         ] .
 
 ldcOnt:measurement_count
         a                owl:Class ;
         rdfs:label       "Measurement_Count" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Item" ;
+                                                owl:unionOf  ( ldcOnt:Ballot ldcOnt:Commodity ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location ldcOnt:Organization ldcOnt:Person ldcOnt:Vehicle ldcOnt:Weapon )
+                                              ] ;
+                           owl:onProperty     ldcOnt:measurement_count_item
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Count" ;
+                                                owl:unionOf  ( ldcOnt:NumericalValue )
+                                              ] ;
+                           owl:onProperty     ldcOnt:measurement_count_count
+                         ] .
 
 ldcOnt:orgafl_empmem  a  owl:Class ;
         rdfs:label       "Organization-Affiliation_Employment-Membership" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_empmem_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Employee" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_empmem_employee
+                         ] .
 
 ldcOnt:orgafl_found  a   owl:Class ;
         rdfs:label       "Organization-Affiliation_Founder" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_found_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Founder" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_found_founder
+                         ] .
 
 ldcOnt:orgafl_invshar
         a                owl:Class ;
         rdfs:label       "Organization-Affiliation_Investor-Shareholder" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_invshar_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "InvestorShareholder" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_invshar_investorshareholder
+                         ] .
 
 ldcOnt:orgafl_lead  a    owl:Class ;
         rdfs:label       "Organization-Affiliation_Leadership" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_lead_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Leader" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_lead_leader
+                         ] .
 
 ldcOnt:orgafl_own  a     owl:Class ;
         rdfs:label       "Organization-Affiliation_Ownership" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_own_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Owner" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_own_owner
+                         ] .
 
 ldcOnt:orgafl_stualm  a  owl:Class ;
         rdfs:label       "Organization-Affiliation_Student-Alum" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_stualm_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "StudentAlum" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:orgafl_stualm_studentalum
+                         ] .
 
 ldcOnt:partwhole_membership
         a                owl:Class ;
         rdfs:label       "Part-Whole_Membership" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:partwhole_membership_organization
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Member" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:partwhole_membership_member
+                         ] .
 
 ldcOnt:partwhole_subsid
         a                owl:Class ;
         rdfs:label       "Part-Whole_Subsidiary" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Parent" ;
+                                                owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:partwhole_subsid_parent
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Subsidiary" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:partwhole_subsid_subsidiary
+                         ] .
 
 ldcOnt:persoc_bus  a     owl:Class ;
         rdfs:label       "Personal-Social_Business" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_bus_person
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_bus_person
+                         ] .
 
 ldcOnt:persoc_fam  a     owl:Class ;
         rdfs:label       "Personal-Social_Family" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_fam_person
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_fam_person
+                         ] .
 
 ldcOnt:persoc_role  a    owl:Class ;
         rdfs:label       "Personal-Social_Role-Title" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Title" ;
+                                                owl:unionOf  ( ldcOnt:Title )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_role_title
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_role_person
+                         ] .
 
 ldcOnt:persoc_unspc  a   owl:Class ;
         rdfs:label       "Personal-Social_Unspecified" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_unspc_person
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Person" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:persoc_unspc_person
+                         ] .
 
 ldcOnt:phys_locnear  a   owl:Class ;
         rdfs:label       "Physical_Located-Near" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Place" ;
+                                                owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_locnear_place
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Entity" ;
+                                                owl:unionOf  ( ldcOnt:Commodity ldcOnt:Facility ldcOnt:Person ldcOnt:Vehicle ldcOnt:Weapon )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_locnear_entity
+                         ] .
 
 ldcOnt:phys_orghq  a     owl:Class ;
         rdfs:label       "Physical_Organization-Headquarter" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Place" ;
+                                                owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_orghq_place
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_orghq_organization
+                         ] .
 
 ldcOnt:phys_orglocorig
         a                owl:Class ;
         rdfs:label       "Physical_Organization-Location-Origin" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Place" ;
+                                                owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_orglocorig_place
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Organization" ;
+                                                owl:unionOf  ( ldcOnt:Organization )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_orglocorig_organization
+                         ] .
 
 ldcOnt:phys_resident  a  owl:Class ;
         rdfs:label       "Physical_Resident" ;
-        rdfs:subClassOf  aidaDomainCommon:RelationType .
+        rdfs:subClassOf  aidaDomainCommon:RelationType ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Place" ;
+                                                owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_resident_place
+                         ] ;
+        rdfs:subClassOf  [ a                  owl:Restriction ;
+                           owl:allValuesFrom  [ a            owl:Class ;
+                                                rdfs:label   "Resident" ;
+                                                owl:unionOf  ( ldcOnt:Person )
+                                              ] ;
+                           owl:onProperty     ldcOnt:phys_resident_resident
+                         ] .
 
 ######################################################
 # Event types
@@ -501,38 +823,38 @@ ldcOnt:EXISTENCE_DAMAGE-DESTROY
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD5" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:existence_damage-destroy_tbd5
+                           owl:onProperty     ldcOnt:existence_damage-destroy_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:existence_damage-destroy_tbd4
+                           owl:onProperty     ldcOnt:existence_damage-destroy_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Instrument" ;
                                                 owl:unionOf  ( ldcOnt:Commodity ldcOnt:Vehicle ldcOnt:Weapon )
                                               ] ;
-                           owl:onProperty     ldcOnt:existence_damage-destroy_tbd3
+                           owl:onProperty     ldcOnt:existence_damage-destroy_instrument
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Victim" ;
                                                 owl:unionOf  ( ldcOnt:Ballot ldcOnt:Commodity ldcOnt:Facility ldcOnt:Vehicle ldcOnt:Weapon )
                                               ] ;
-                           owl:onProperty     ldcOnt:existence_damage-destroy_tbd2
+                           owl:onProperty     ldcOnt:existence_damage-destroy_victim
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Agent" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:existence_damage-destroy_tbd1
+                           owl:onProperty     ldcOnt:existence_damage-destroy_agent
                          ] .
 
 ldcOnt:GOVERNMENT_AGREEMENTS
@@ -540,24 +862,24 @@ ldcOnt:GOVERNMENT_AGREEMENTS
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_agreements_tbd3
+                           owl:onProperty     ldcOnt:government_agreements_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_agreements_tbd2
+                           owl:onProperty     ldcOnt:government_agreements_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Signer" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_agreements_tbd1
+                           owl:onProperty     ldcOnt:government_agreements_signer
                          ] .
 
 ldcOnt:GOVERNMENT_LEGISLATE
@@ -565,31 +887,31 @@ ldcOnt:GOVERNMENT_LEGISLATE
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_legislate_tbd4
+                           owl:onProperty     ldcOnt:government_legislate_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_legislate_tbd3
+                           owl:onProperty     ldcOnt:government_legislate_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Law" ;
                                                 owl:unionOf  ( ldcOnt:Law )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_legislate_tbd2
+                           owl:onProperty     ldcOnt:government_legislate_law
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Legislature" ;
                                                 owl:unionOf  ( ldcOnt:Organization )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_legislate_tbd1
+                           owl:onProperty     ldcOnt:government_legislate_legislature
                          ] .
 
 ldcOnt:GOVERNMENT_SPY
@@ -597,38 +919,38 @@ ldcOnt:GOVERNMENT_SPY
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD5" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_spy_tbd5
+                           owl:onProperty     ldcOnt:government_spy_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_spy_tbd4
+                           owl:onProperty     ldcOnt:government_spy_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Beneficiary" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_spy_tbd3
+                           owl:onProperty     ldcOnt:government_spy_beneficiary
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Target" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_spy_tbd2
+                           owl:onProperty     ldcOnt:government_spy_target
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Agent" ;
                                                 owl:unionOf  ( ldcOnt:Person )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_spy_tbd1
+                           owl:onProperty     ldcOnt:government_spy_agent
                          ] .
 
 ldcOnt:GOVERNMENT_VOTE
@@ -636,45 +958,45 @@ ldcOnt:GOVERNMENT_VOTE
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD6" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_vote_tbd6
+                           owl:onProperty     ldcOnt:government_vote_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD5" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_vote_tbd5
+                           owl:onProperty     ldcOnt:government_vote_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Results" ;
                                                 owl:unionOf  ( ldcOnt:Results )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_vote_tbd4
+                           owl:onProperty     ldcOnt:government_vote_results
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Ballot" ;
                                                 owl:unionOf  ( ldcOnt:Ballot )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_vote_tbd3
+                           owl:onProperty     ldcOnt:government_vote_ballot
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Candidate" ;
                                                 owl:unionOf  ( ldcOnt:Law ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_vote_tbd2
+                           owl:onProperty     ldcOnt:government_vote_candidate
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Voter" ;
                                                 owl:unionOf  ( ldcOnt:Person )
                                               ] ;
-                           owl:onProperty     ldcOnt:government_vote_tbd1
+                           owl:onProperty     ldcOnt:government_vote_voter
                          ] .
 
 ldcOnt:INSPECTION_ARTIFACT
@@ -682,31 +1004,31 @@ ldcOnt:INSPECTION_ARTIFACT
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_artifact_tbd4
+                           owl:onProperty     ldcOnt:inspection_artifact_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_artifact_tbd3
+                           owl:onProperty     ldcOnt:inspection_artifact_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Thing" ;
                                                 owl:unionOf  ( ldcOnt:Ballot ldcOnt:Commodity ldcOnt:Facility ldcOnt:Vehicle ldcOnt:Weapon )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_artifact_tbd2
+                           owl:onProperty     ldcOnt:inspection_artifact_thing
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Inspector" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_artifact_tbd1
+                           owl:onProperty     ldcOnt:inspection_artifact_inspector
                          ] .
 
 ldcOnt:INSPECTION_PEOPLE
@@ -714,31 +1036,31 @@ ldcOnt:INSPECTION_PEOPLE
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_people_tbd4
+                           owl:onProperty     ldcOnt:inspection_people_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_people_tbd3
+                           owl:onProperty     ldcOnt:inspection_people_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Person" ;
                                                 owl:unionOf  ( ldcOnt:Person )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_people_tbd2
+                           owl:onProperty     ldcOnt:inspection_people_person
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Inspector" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:inspection_people_tbd1
+                           owl:onProperty     ldcOnt:inspection_people_inspector
                          ] .
 
 ldcOnt:JUSTICE_ACQUIT
@@ -1085,38 +1407,38 @@ ldcOnt:JUSTICE_INVESTIGATE
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD5" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:justice_investigate_tbd5
+                           owl:onProperty     ldcOnt:justice_investigate_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:justice_investigate_tbd4
+                           owl:onProperty     ldcOnt:justice_investigate_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Crime" ;
                                                 owl:unionOf  ( ldcOnt:Crime )
                                               ] ;
-                           owl:onProperty     ldcOnt:justice_investigate_tbd3
+                           owl:onProperty     ldcOnt:justice_investigate_crime
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Investigatee" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:justice_investigate_tbd2
+                           owl:onProperty     ldcOnt:justice_investigate_investigatee
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Investigator" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:justice_investigate_tbd1
+                           owl:onProperty     ldcOnt:justice_investigate_investigator
                          ] .
 
 ldcOnt:JUSTICE_PARDON
@@ -1799,45 +2121,45 @@ ldcOnt:TRANSACTION_TRANSFER-CONTROL
         rdfs:subClassOf  aidaDomainCommon:EventType ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD6" ;
+                                                rdfs:label   "Time" ;
                                                 owl:unionOf  ( ldcOnt:Time )
                                               ] ;
-                           owl:onProperty     ldcOnt:transaction_transfer-control_tbd6
+                           owl:onProperty     ldcOnt:transaction_transfer-control_time
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD5" ;
+                                                rdfs:label   "Place" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:transaction_transfer-control_tbd5
+                           owl:onProperty     ldcOnt:transaction_transfer-control_place
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD4" ;
+                                                rdfs:label   "Territory" ;
                                                 owl:unionOf  ( ldcOnt:Facility ldcOnt:GeopoliticalEntity ldcOnt:Location )
                                               ] ;
-                           owl:onProperty     ldcOnt:transaction_transfer-control_tbd4
+                           owl:onProperty     ldcOnt:transaction_transfer-control_territory
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD3" ;
+                                                rdfs:label   "Beneficiary" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:transaction_transfer-control_tbd3
+                           owl:onProperty     ldcOnt:transaction_transfer-control_beneficiary
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD2" ;
+                                                rdfs:label   "Recipient" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:transaction_transfer-control_tbd2
+                           owl:onProperty     ldcOnt:transaction_transfer-control_recipient
                          ] ;
         rdfs:subClassOf  [ a                  owl:Restriction ;
                            owl:allValuesFrom  [ a            owl:Class ;
-                                                rdfs:label   "TBD1" ;
+                                                rdfs:label   "Giver" ;
                                                 owl:unionOf  ( ldcOnt:GeopoliticalEntity ldcOnt:Organization ldcOnt:Person ldcOnt:Sides )
                                               ] ;
-                           owl:onProperty     ldcOnt:transaction_transfer-control_tbd1
+                           owl:onProperty     ldcOnt:transaction_transfer-control_giver
                          ] .
 
 ldcOnt:TRANSACTION_TRANSFER-MONEY

--- a/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
+++ b/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
@@ -39,6 +39,12 @@ public class ExamplesAndValidationTest {
       Resources.asCharSource(Resources.getResource("edu/isi/gaia/seedling-ontology.ttl"),
           Charsets.UTF_8));
 
+    private int assertionCount = 1;
+
+    private String getAssertionUri() {
+        return "http://www.test.org/assertions/" + assertionCount++;
+    }
+
 @Nested
 class ValidExamples {
 
@@ -139,17 +145,17 @@ class ValidExamples {
         // they were born in Louisville or Cambridge
         final Resource personEntity = AIFUtils
                 .makeEntity(model, "http://www.test.edu/entities/1", system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/1",
+        AIFUtils.markType(model, getAssertionUri(),
                 personEntity, SeedlingOntologyMapper.PERSON, system, 1.0);
 
         // create entities for the two locations
         final Resource louisvilleEntity = AIFUtils
                 .makeEntity(model, "http://www.test.edu/entities/2", system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/2",
+        AIFUtils.markType(model, getAssertionUri(),
                 louisvilleEntity, SeedlingOntologyMapper.GPE, system, 1.0);
         final Resource cambridgeEntity = AIFUtils
                 .makeEntity(model, "http://www.test.edu/entities/3", system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/3",
+        AIFUtils.markType(model, getAssertionUri(),
                 cambridgeEntity, SeedlingOntologyMapper.GPE, system, 1.0);
 
         // create an entity for the uncertain place of birth
@@ -157,9 +163,12 @@ class ValidExamples {
                 .makeEntity(model, "http://www.test.edu/entities/4", system);
 
         // whatever this place turns out to refer to, we're sure it's where they live
-        makeRelation(model, "http://www.test.edu/relations/1", personEntity,
-                ontologyMapping.relationType("cities_of_residence"),
-                uncertainPlaceOfBirthEntity, system, 1.0);
+        String relation = "phys_resident";
+        makeRelationInEventForm(model, "http://www.test.edu/relations/1",
+                ontologyMapping.relationType(relation),
+                ontologyMapping.eventArgumentType(relation + "_resident"), personEntity,
+                ontologyMapping.eventArgumentType(relation + "_place"), uncertainPlaceOfBirthEntity,
+                getAssertionUri(), system, 1.0);
 
         // we use clusters to represent uncertainty about identity
         // we make two clusters, one for Louisville and one for Cambridge
@@ -216,9 +225,9 @@ class ValidExamples {
                 SeedlingOntologyMapper.GPE, system, 1.0);
 
         // link those entities to the event
-        AIFUtils.markAsEventArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_elect"),
+        AIFUtils.markAsArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_elect"),
                 electee, system, 0.785);
-        AIFUtils.markAsEventArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_place"),
+        AIFUtils.markAsArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_place"),
                 electionCountry, system, 0.589);
 
         dumpAndAssertValid(model, "create a seedling event", true);
@@ -259,9 +268,9 @@ class ValidExamples {
                 SeedlingOntologyMapper.GPE, system, 1.0);
 
         // link those entities to the event
-        AIFUtils.markAsEventArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_elect"),
+        AIFUtils.markAsArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_elect"),
                 electee, system, 0.785, "http://www.test.edu/eventArgument/1");
-        AIFUtils.markAsEventArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_place"),
+        AIFUtils.markAsArgument(model, event, ontologyMapping.eventArgumentType("personnel_elect_place"),
                 electionCountry, system, 0.589, "http://www.test.edu/eventArgument/2");
 
         dumpAndAssertValid(model, "create a seedling event", true);
@@ -301,15 +310,15 @@ class ValidExamples {
 
         // we link all possible argument fillers to the event
         final ImmutableSet<Resource> bobHitFredAssertions = ImmutableSet.of(
-                AIFUtils.markAsEventArgument(model, event,
+                AIFUtils.markAsArgument(model, event,
                         ontologyMapping.eventArgumentType("conflict_attack_attacker"), bob, system, null),
-                AIFUtils.markAsEventArgument(model, event,
+                AIFUtils.markAsArgument(model, event,
                         ontologyMapping.eventArgumentType("conflict_attack_target"), fred, system, null));
 
         final ImmutableSet<Resource> fredHitBobAssertions = ImmutableSet.of(
-                AIFUtils.markAsEventArgument(model, event,
+                AIFUtils.markAsArgument(model, event,
                         ontologyMapping.eventArgumentType("conflict_attack_attacker"), fred, system, null),
-                AIFUtils.markAsEventArgument(model, event,
+                AIFUtils.markAsArgument(model, event,
                         ontologyMapping.eventArgumentType("conflict_attack_target"), bob, system, null));
 
         // then we mark these as mutually exclusive
@@ -334,48 +343,63 @@ class ValidExamples {
         // named Bob, two companies (Google and Amazon), and two places (Seattle and California).
         final Resource bob = AIFUtils.makeEntity(model, "http://www.test.edu/entities/Bob",
                 system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/1",
+        AIFUtils.markType(model, getAssertionUri(),
                 bob, SeedlingOntologyMapper.PERSON, system, 1.0);
         final Resource google = AIFUtils.makeEntity(model, "http://www.test.edu/entities/Google",
                 system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/2",
+        AIFUtils.markType(model, getAssertionUri(),
                 google, SeedlingOntologyMapper.ORGANIZATION, system, 1.0);
         final Resource amazon = AIFUtils.makeEntity(model, "http://www.test.edu/entities/Amazon",
                 system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/3",
+        AIFUtils.markType(model, getAssertionUri(),
                 amazon, SeedlingOntologyMapper.ORGANIZATION, system, 1.0);
         final Resource seattle = AIFUtils.makeEntity(model, "http://www.test.edu/entities/Seattle",
                 system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/4",
+        AIFUtils.markType(model, getAssertionUri(),
                 seattle, SeedlingOntologyMapper.GPE, system, 1.0);
         final Resource california = AIFUtils
                 .makeEntity(model, "http://www.test.edu/entities/California",
                         system);
-        AIFUtils.markType(model, "http://www.test.org/assertions/5",
+        AIFUtils.markType(model, getAssertionUri(),
                 california, SeedlingOntologyMapper.GPE, system, 1.0);
 
         // under the background hypothesis that Bob lives in Seattle, we believe he works for Amazon
-        final Resource bobLivesInSeattle = makeRelation(model, "http://www.test.edu/relations/1",
-                bob, ontologyMapping.relationType("cities_of_residence"),
-                seattle, system, 1.0);
+        String cityRelation = "phys_resident";
+        String cityRelationSubject = cityRelation + "_resident";
+        String cityRelationObject = cityRelation + "_place";
+        final Resource bobLivesInSeattle = makeRelationInEventForm(model, "http://www.test.edu/relations/1",
+                ontologyMapping.relationType(cityRelation),
+                ontologyMapping.eventArgumentType(cityRelationSubject), bob,
+                ontologyMapping.eventArgumentType(cityRelationObject), seattle,
+                getAssertionUri(), system, 1.0);
         final Resource bobLivesInSeattleHypothesis = makeHypothesis(model,
                 "http://www.test.edu/hypotheses/1", ImmutableSet.of(bobLivesInSeattle),
                 system);
-        final Resource bobWorksForAmazon = makeRelation(model, "http://www.test.edu/relations/2",
-                bob, ontologyMapping.relationType("employee_or_member_of"),
-                amazon, system, 1.0);
+
+        String employeeRelation = "orgafl_empmem";
+        String employeeRelationSubject = employeeRelation + "_employee";
+        String employeeRelationOjbect = employeeRelation + "_organization";
+        final Resource bobWorksForAmazon = makeRelationInEventForm(model, "http://www.test.edu/relations/2",
+                ontologyMapping.relationType(employeeRelation),
+                ontologyMapping.eventArgumentType(employeeRelationSubject), bob,
+                ontologyMapping.eventArgumentType(employeeRelationOjbect), amazon,
+                getAssertionUri(), system, 1.0);
         markDependsOnHypothesis(bobWorksForAmazon, bobLivesInSeattleHypothesis);
 
         // under the background hypothesis that Bob lives in California, we believe he works for Google
-        final Resource bobLivesInCalifornia = makeRelation(model, "http://www.test.edu/relations/3",
-                bob, ontologyMapping.relationType("cities_of_residence"),
-                california, system, 1.0);
+        final Resource bobLivesInCalifornia = makeRelationInEventForm(model, "http://www.test.edu/relations/3",
+                ontologyMapping.relationType(cityRelation),
+                ontologyMapping.eventArgumentType(cityRelationSubject), bob,
+                ontologyMapping.eventArgumentType(cityRelationObject), california,
+                getAssertionUri(), system, 1.0);
         final Resource bobLivesInCaliforniaHypothesis = makeHypothesis(model,
                 "http://www.test.edu/hypotheses/2", ImmutableSet.of(bobLivesInCalifornia),
                 system);
-        final Resource bobWorksForGoogle = makeRelation(model, "http://www.test.edu/relations/4",
-                bob, ontologyMapping.relationType("employee_or_member_of"),
-                google, system, 1.0);
+        final Resource bobWorksForGoogle = makeRelationInEventForm(model, "http://www.test.edu/relations/4",
+                ontologyMapping.relationType(employeeRelation),
+                ontologyMapping.eventArgumentType(employeeRelationSubject), bob,
+                ontologyMapping.eventArgumentType(employeeRelationOjbect), google,
+                getAssertionUri(), system, 1.0);
         markDependsOnHypothesis(bobWorksForGoogle, bobLivesInCaliforniaHypothesis);
 
         dumpAndAssertValid(model, "two seedling hypotheses", true);
@@ -465,9 +489,12 @@ class ValidExamples {
               .makeEntity(model, "http://www.test.edu/entities/2", system);
       AIFUtils.markType(model, "http://www.test.org/assertions/1",
               louisvilleEntity, SeedlingOntologyMapper.GPE, system, 1.0);
-      makeRelation(model, "http://www.test.edu/relations/1", personEntity,
-              model.createResource(SeedlingOntologyMapper.NAMESPACE_STATIC + "unknown_type"),
-              louisvilleEntity, system, 1.0);
+
+        String relation = SeedlingOntologyMapper.NAMESPACE_STATIC + "unknown_type";
+        makeRelationInEventForm(model, "http://www.test.edu/relations/1", model.createResource(relation),
+                ontologyMapping.eventArgumentType(relation + "_person"), personEntity,
+                ontologyMapping.eventArgumentType(relation + "_person"), louisvilleEntity,
+                getAssertionUri(), system, 1.0);
 
       assertFalse(seedlingValidator.validateKB(model));
     }


### PR DESCRIPTION
* Added RelationArgumentType.
Modified AIFUtils.makeRelation and added AIFUtils.makeRelationInEventForm.
Modified SHACL to allow for relation subclasses to have type.
Commenting out RDFStatementShape until SeedlingOntology contains relation arguments.
Modified Examples to use relations in event-form

* Remove extraneous RelationSubclass from shacl.
Add RelationArgumentType to shacl.
Add back RdfStatementShape to shal.
Update seedling-ontologies.
Update examples to use seedling relations.

* Shorten relation argument names in seedling ontologies.
Modify test to use apporpriate names.

* Add latest labels from NIST.
Revert back to label-like uris for event arguments.