### PR TITLE
AIDA-294: CompoundJustifications

### DIFF
--- a/src/main/java/edu/isi/gaia/AidaAnnotationOntology.kt
+++ b/src/main/java/edu/isi/gaia/AidaAnnotationOntology.kt
@@ -26,6 +26,9 @@ object AidaAnnotationOntology {
     @JvmField
     val JUSTIFIED_BY = ResourceFactory.createProperty(NAMESPACE + "justifiedBy")!!
     @JvmField
+    val CONTAINED_JUSTIFICATION =
+            ResourceFactory.createProperty(NAMESPACE + "containedJustification")!!
+    @JvmField
     val SOURCE = ResourceFactory.createProperty(NAMESPACE + "source")!!
     @JvmField
     val START_OFFSET = ResourceFactory.createProperty(NAMESPACE + "startOffset")!!
@@ -122,6 +125,9 @@ object AidaAnnotationOntology {
     @JvmField
     val SHOT_VIDEO_JUSTIFICATION_CLASS =
             ResourceFactory.createResource(NAMESPACE + "ShotVideoJustification")!!
+    @JvmField
+    val COMPOUND_JUSTIFICATION_CLASS =
+            ResourceFactory.createResource(NAMESPACE + "CompoundJustification")!!
     @JvmField
     val LINK_ASSERTION_CLASS = ResourceFactory.createResource(NAMESPACE + "LinkAssertion")!!
     @JvmField

--- a/src/main/resources/edu/isi/gaia/aida_ontology.shacl
+++ b/src/main/resources/edu/isi/gaia/aida_ontology.shacl
@@ -696,15 +696,37 @@ aida:ShotVideoJustificationShape
    # except rdf:type
    sh:ignoredProperties (rdf:type) .
 
+aida:CompoundJustificationShape
+   a sh:NodeShape ;
+   sh:targetClass aida:CompoundJustification ;
+
+   # must have at least two contained justifications
+   sh:property [
+     sh:path aida:containedJustification ;
+     sh:xone (
+       [sh:class aida:TextJustification]
+       [sh:class aida:ImageJustification]
+       [sh:class aida:AudioJustification]
+       [sh:class aida:KeyFrameVideoJustification]
+       [sh:class aida:ShotVideoJustification] ) ;
+     sh:minCount 2 ] ;
+
+   # justification must provide confidence
+   sh:property aida:RequiredConfidencePropertyShape ;
+
+   # may provide an optional source system
+   sh:property aida:SystemPropertyShape .
+
 aida:JustificationPropertyShape
    a sh:PropertyShape ;
    sh:path aida:justifiedBy ;
-   sh:exone (
+   sh:xone (
      [sh:class aida:TextJustification]
      [sh:class aida:ImageJustification]
      [sh:class aida:AudioJustification]
      [sh:class aida:KeyFrameVideoJustification]
-     [sh:class aida:ShotVideoJustification] ).
+     [sh:class aida:ShotVideoJustification]
+     [sh:class aida:CompoundJustification] ).
 
 # use to express that an AIDA Entity is the same thing as something in an external knowledge base
 aida:LinkAssertionShape

--- a/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
+++ b/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
@@ -473,12 +473,61 @@ class ValidExamples {
         AIFUtils.markName(entity, "N-Money");
 
         AIFUtils.markTextValue(entity, "TextValue");
-        
+
         AIFUtils.markNumericValueAsDouble(entity, 100);
         AIFUtils.markNumericValueAsLong(entity, 100);
         AIFUtils.markNumericValueAsString(entity, "100");
 
         dumpAndAssertValid(model, "create a seedling entity of type person with names", true);
+    }
+
+    @Test
+    void createCompoundJustification() {
+        final Model model = createModel(true);
+
+        // every AIF needs an object for the system responsible for creating it
+        final Resource system = AIFUtils.makeSystemWithURI(model, "http://www.test.edu/testSystem");
+
+        // it doesn't matter what URI we give entities, events, etc. so long as they are
+        // unique
+        final Resource entity = AIFUtils.makeEntity(model, "http://www.test.edu/entities/1", system);
+
+        // in order to allow uncertainty about the type of an entity, we don't mark an
+        // entity's type directly on the entity, but rather make a separate assertion for it
+        // its URI doesn't matter either
+        final Resource typeAssertion = AIFUtils.markType(model, "http://www.test.org/assertions/1",
+                entity, SeedlingOntologyMapper.PERSON, system, 1.0);
+
+        // the justification provides the evidence for our claim about the entity's type
+        // we attach this justification to both the type assertion and the entity object
+        // itself, since it provides evidence both for the entity's existence and its type.
+        // in TA1 -> TA2 communications, we attach confidences at the level of justifications
+        final Resource textJustification = AIFUtils.makeTextJustification(model, "NYT_ENG_20181231",
+                42, 143, system, 0.973);
+
+        // let's suppose we also have evidence from an image
+        final Resource imageJustification = AIFUtils.makeImageJustification(model, "NYT_ENG_20181231_03",
+                new BoundingBox(new Point(123, 45), new Point(167, 98)), system, 0.123);
+
+        // and also a video where the entity appears in a keyframe
+        final Resource keyFrameVideoJustification = AIFUtils.makeKeyFrameVideoJustification(model,
+                "NYT_ENG_20181231_03", "keyframe ID",
+                new BoundingBox(new Point(234, 56), new Point(345, 101)), system, 0.234);
+
+        // and also a video where the entity does not appear in a keyframe
+        final Resource shotVideoJustification = AIFUtils.makeShotVideoJustification(model, "SOME_VIDEO",
+                "some shot ID", system, 0.487);
+
+        // and even audio!
+        final Resource audioJustification = AIFUtils.makeAudioJustification(model, "NYT_ENG_201181231",
+                4.566, 9.876, system, 0.789);
+
+        // combine all jutifications into single justifiedBy triple with new confidence
+        AIFUtils.markCompoundJustification(model, ImmutableSet.of(entity),
+                ImmutableSet.of(textJustification, imageJustification, keyFrameVideoJustification,
+                        shotVideoJustification, audioJustification), system, 0.321);
+
+        dumpAndAssertValid(model, "create a compound justification", true);
     }
 }
 


### PR DESCRIPTION
Add method to AIFUtils to mark CompoundJustification.
Add methods to AIFUtils to create each of the justification types independently of marking them.
Added way to mark justifications after they are created.
Modified shacl to allow things to be justified by CompoundJustifications and a constraint for CompoundJustificationShape.
Added test to showcase CompoundJustification.