### PR TITLE
Aida 358 -- Example that reads and writes to disk

### DIFF
--- a/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
+++ b/src/test/java/edu/isi/gaia/ExamplesAndValidationTest.java
@@ -1135,7 +1135,6 @@ class ValidExamples {
     System.out.println("Creating disk based model at " + tempLoc);
     Dataset dataset = TDBFactory.createDataset(tempLoc);
     Model model = dataset.getDefaultModel();
-    // model = ModelFactory.createDefaultModel();
     return addNamespacesToModel(model, seedling);
   }
 


### PR DESCRIPTION
Added a new function that creates a disk-based model (that can scale higher), added an example that uses it, writes out to a TTL file, reads the model back in, and then verifies that the entity is in there.