### PR TITLE
Aida 554: Run validator performance benchmarks on HAL 2.0

### DIFF
--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -370,7 +370,9 @@ public final class ValidateAIF {
             logger.info("-> Validating " + fileToValidate + " at " + format.format(date) +
                     " (" + fileNum++ + " of " + filesToValidate.size() + ").");
 
-            final Model dataToBeValidated = ModelFactory.createOntologyModel();
+            final OntModel dataToBeValidated = ModelFactory.createOntologyModel();
+            dataToBeValidated.addLoadedImport(INTERCHANGE_URI);
+            dataToBeValidated.addLoadedImport(AIDA_DOMAIN_COMMON_URI);
             try {
                 loadModel(dataToBeValidated, Files.asCharSource(fileToValidate, Charsets.UTF_8));
             } catch (RuntimeException rte) {

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -244,7 +244,7 @@ aida:RelationArgumentShape
   sh:property [
     sh:path rdf:subject ;
     sh:class aida:Relation ;
-    sh:message "The subject of a relation argument must be an relation"
+    sh:message "The subject of a relation argument must be a relation"
   ] ;
 
   # the object is the entity participating in the event
@@ -1248,7 +1248,6 @@ aida:DependsOnHypothesisPropertyShape
 
 aida:PrivateDataShape
    sh:targetClass aida:PrivateData ;
-   sh:property aida:RequiredSystemPropertyShape ;
    sh:property aida:JsonContentPropertyShape ;
    # this class is not closed, so you can stick whatever else you want here
    .

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -24,13 +24,11 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.UUID;
 
 import static com.ncc.aif.AIFUtils.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1378,12 +1376,17 @@ public class ExamplesAndValidationTest {
     }
 
     private Model createDiskBasedModel() {
-        String tempDir = System.getProperty("java.io.tmpdir");
-        String tempLoc = tempDir + File.separator + "model-scaling-" + UUID.randomUUID();
-        System.out.println("Creating disk based model at " + tempLoc);
-        Dataset dataset = TDBFactory.createDataset(tempLoc);
-        Model model = dataset.getDefaultModel();
-        return addNamespacesToModel(model);
+        try {
+            final Path outputPath = Files.createTempDirectory("diskbased-model-");
+            System.out.println("Creating disk based model at " + outputPath.toString());
+            final Dataset dataset = TDBFactory.createDataset(outputPath.toString());
+            final Model model = dataset.getDefaultModel();
+            return addNamespacesToModel(model);
+        } catch (Exception e) {
+            System.err.println("Unable to create temp directory: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
     }
 
     private Model addNamespacesToModel(Model model) {

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -27,8 +27,8 @@ import static com.ncc.aif.AIFUtils.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test to see how large we can scale AIF.  AIF uses a Jena-based model, and so we rely on that
- * to determine how large it can get.  Change whether you are using a memory based model
+ * Test to see how large we can scale AIF with the LDC Seedling ontology.  AIF uses a Jena-based model,
+ * and so we rely on that to determine how large it can get.  Change whether you are using a memory based model
  * or a disk-based model (TDB) below in the line that defines modelTypeToUse.  MEMORY is faster, but
  * is more limited;  TDB is slower but can handle more statements.
  * <p>
@@ -53,14 +53,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 123285222  scalingdata.ttl.TriX
  * <p>
  * The smaller ones are difficult to read, the large ones do not use prefixes. turtle_pretty is readable and not too large.
+ * By default, this class runs a scaling test using the Turtle Pretty output type.
  * <p>
  * Run with:
- * %  mvn exec:java -Dexec.mainClass="edu.isi.aif.ScalingTest" -Dexec.classpathScope="test" -Dexec.args="[arguments]"
+ * %  mvn exec:java -Dexec.mainClass="com.ncc.aif.ScalingTest" -Dexec.classpathScope="test" -Dexec.args="[arguments]"
  * where arguments are:
  * <pre>
- *       -o   try different output types (default is to use Turtle Pretty and scale)
+ *       -s   run a single test on a single output type (i.e., do not scale)
+ *       -o   run a single test on different output types (incompatible with -s and -v)
  *       -t   use tdb model (default is to use in-memory)
- *       -p   do validation (default is to not do validation)
+ *       -v   do validation (default is to not do validation, incompatible with -o)
  * </pre>
  */
 public class ScalingTest {
@@ -118,10 +120,15 @@ public class ScalingTest {
     // Set this to no perform scaling, but rather try different output formats
     private boolean useMultipleOutputs = false;
 
+    // Set this to true to run multiple, scaling tests, or false to run a single unscaled test
+    private boolean runScalingTest = true;
+
     /**
      * Main function.  See class description for arguments.
      */
     public static void main(String[] args) {
+        // prevent too much logging from obscuring the Turtle examples which will be printed
+        ((Logger) org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.INFO);
         ScalingTest scalingTest = new ScalingTest();
         scalingTest.parseArgs(Arrays.asList(args));
         scalingTest.runTest();
@@ -129,59 +136,77 @@ public class ScalingTest {
 
     private void parseArgs(List<String> args) {
 
-        // prevent too much logging from obscuring the Turtle examples which will be printed
-        ((Logger) org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.INFO);
-
         if (args.contains("-o")) {
             useMultipleOutputs = true;
+            runScalingTest = false;
+            if (args.contains("-s")) {
+                System.err.println("Please use only one of -o and -s.");
+                System.exit(1);
+            }
+        }
+
+        if (args.contains("-s")) {
+            runScalingTest = false;
         }
 
         if (args.contains("-t")) {
             modelTypeToUse = MODEL_TYPE.TDB;
         }
 
-        if (args.contains("-p")) {
+        if (args.contains("-v")) {
             performValidation = true;
         }
+
+        if (useMultipleOutputs && performValidation) {
+            System.err.println("Cannot perform validation on multiple output type tests.");
+            System.exit(1);
+        }
+
     }
 
     private void runTest() {
 
         if (useMultipleOutputs) {
-            runSingleTest();
+            runOneTest();
             dumpMultipleFormats();
-        } else {
-            runMultipleTests();
+        } else if (runScalingTest) {
+            runScalingTest();
+        }
+        else {
+            runSingleTest();
         }
     }
 
-    private void runMultipleTests() {
+    private void runScalingTest() {
 
         for (int ii = 0; ii < 200; ii++) {
-            System.out.print("Trying :  Entity count: " + entityCount + " ");
-            long startTime = System.currentTimeMillis();
-
             runSingleTest();
-
-            dumpAndAssertValid();
-
-            long endTime = System.currentTimeMillis();
-            long duration = (endTime - startTime) / 1000;
-
-            long size = 0;
-            File f = new File(filename);
-            if (f.exists()) {
-                size = f.length();
-            }
-            size /= 1000000.;      // Convert from milliseconds to seconds.
-            System.out.println(" Size of output (mb): " + size + "  Time (sec): " + duration);
-
             entityCount *= 2;
             eventCount *= 2;
         }
     }
 
     private void runSingleTest() {
+        System.out.print("Trying :  Entity count: " + entityCount + " ");
+        long startTime = System.currentTimeMillis();
+
+        runOneTest();
+
+        dumpAndAssertValid();
+
+        long endTime = System.currentTimeMillis();
+        long duration = (endTime - startTime) / 1000;      // Convert from milliseconds to seconds.
+
+        long size = 0;
+        File f = new File(filename);
+        if (f.exists()) {
+            size = f.length();
+        }
+        size /= 1000000.;      // Convert from bytes to megabytes.
+        System.out.println(" Size of output (mb): " + size + "  Time (sec): " + duration);
+    }
+
+    private void runOneTest() {
         createModel();
         system = makeSystemWithURI(model, getTestSystemUri());
 
@@ -190,7 +215,7 @@ public class ScalingTest {
             addEntity();
         }
         for (int ii = 0; ii < eventCount; ii++) {
-            addEvent();
+            addEventOrRelation();
         }
 
         int numStatements = 0;
@@ -208,27 +233,67 @@ public class ScalingTest {
         Resource entityResource = makeEntity(model, getEntityUri(), system);
         entityResourceList.add(entityResource);
 
-        // sometimes add hasName, textValue, or numericValue, NOTE:  This does not check type!!!!
+        // sometimes add hasName, textValue, or numericValue
         double rand = r.nextDouble();
+        Resource typeToUse;
         if (rand < 0.15) {
             markName(entityResource, getRandomString(5));
+            typeToUse = SeedlingOntology.Person;
         } else if (rand < 0.3) {
             markTextValue(entityResource, getRandomString(7));
+            typeToUse = SeedlingOntology.Results;
         } else if (rand < 0.4) {
             markNumericValueAsDouble(entityResource, r.nextDouble());
+            typeToUse = SeedlingOntology.Age;
+        }
+        else {
+            typeToUse = SeedlingOntology.Person;
         }
 
         // Set the type
-        Resource typeToUse = SeedlingOntology.Person;
         Resource typeAssertion = markType(model, getAssertionUri(), entityResource,
                 typeToUse, system, 1.0);
 
         addJustificationAndPrivateData(typeAssertion);
     }
 
+    private void addEventOrRelation() {
+        // sometimes add an event, other times a relation
+        double rand = r.nextDouble();
+        if (rand < 0.5) {
+            addEvent();
+        }
+        else {
+            addRelation();
+        }
+    }
+
     private void addEvent() {
         // Add an event
         Resource eventResource = makeEvent(model, getEventUri(), system);
+
+        // Set the type
+        Resource typeResource = SeedlingOntology.Business_DeclareBankruptcy;
+        Resource typeAssertion = markType(model, getAssertionUri(), eventResource, typeResource, system, 1.0);
+
+        addJustificationAndPrivateData(typeAssertion);
+
+        // Make two arguments
+        Resource argument = markAsArgument(model, eventResource,
+                SeedlingOntology.Business_DeclareBankruptcy_Place,
+                getRandomEntity(), system, 0.785, getAssertionUri());
+        addJustificationAndPrivateData(argument);
+
+        Resource argumentTwo = markAsArgument(model, eventResource,
+                SeedlingOntology.Business_DeclareBankruptcy_Organization,
+                getRandomEntity(), system, 0.785, getAssertionUri());
+        addJustificationAndPrivateData(argumentTwo);
+
+    }
+
+    private void addRelation() {
+        // Add a relation
+        Resource eventResource = makeRelation(model, getEventUri(), system);
 
         // Set the type
         Resource typeResource = SeedlingOntology.Physical_Resident;
@@ -259,7 +324,7 @@ public class ScalingTest {
     }
 
     private final ValidateAIF seedlingValidator = ValidateAIF.createForDomainOntologySource(
-            Resources.asCharSource(Resources.getResource("edu/isi/gaia/SeedlingOntology"), StandardCharsets.UTF_8));
+            Resources.asCharSource(Resources.getResource("com/ncc/aif/ontologies/SeedlingOntology"), StandardCharsets.UTF_8));
 
     // we dump the test name and the model in Turtle format so that whenever the user
     // runs the tests, they will also get the examples
@@ -269,7 +334,7 @@ public class ScalingTest {
         try {
             RDFDataMgr.write(Files.newOutputStream(Paths.get(filename)), model, RDFFormat.TURTLE_PRETTY);
             if (performValidation) {
-                System.out.println("Doing validation");
+                System.out.println("\nDoing validation.  Validation errors (if any) follow:");
                 assertTrue(seedlingValidator.validateKB(model));
             }
         } catch (Exception e) {
@@ -306,7 +371,9 @@ public class ScalingTest {
 
             case TDB:
                 // Make a disk model
-                Dataset dataset = TDBFactory.createDataset("/tmp/model-scaling-" + UUID.randomUUID());
+                String tempDir = System.getProperty("java.io.tmpdir");
+                String tempLoc = tempDir + File.separator + "model-scaling-" + UUID.randomUUID();
+                Dataset dataset = TDBFactory.createDataset(tempLoc);
                 model = dataset.getDefaultModel();
                 break;
 

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -171,8 +171,7 @@ public class ScalingTest {
             dumpMultipleFormats();
         } else if (runScalingTest) {
             runScalingTest();
-        }
-        else {
+        } else {
             runSingleTest();
         }
     }
@@ -245,8 +244,7 @@ public class ScalingTest {
         } else if (rand < 0.4) {
             markNumericValueAsDouble(entityResource, r.nextDouble());
             typeToUse = SeedlingOntology.Age;
-        }
-        else {
+        } else {
             typeToUse = SeedlingOntology.Person;
         }
 
@@ -262,8 +260,7 @@ public class ScalingTest {
         double rand = r.nextDouble();
         if (rand < 0.5) {
             addEvent();
-        }
-        else {
+        } else {
             addRelation();
         }
     }

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * %  mvn exec:java -Dexec.mainClass="com.ncc.aif.ScalingTest" -Dexec.classpathScope="test" -Dexec.args="[arguments]"
  * where arguments are:
  * <pre>
- *       -s   run a single test on a single output type (i.e., do not scale)
+ *       -s   run a single test on a single output type (i.e., do not scale). Incompatible with -o.
  *       -o   run a single test on different output types (incompatible with -s and -v)
  *       -t   use tdb model (default is to use in-memory)
  *       -v   do validation (default is to not do validation, incompatible with -o)
@@ -358,8 +358,7 @@ public class ScalingTest {
             case TDB:
                 try {
                     // Make a disk model
-                    final Path local = FileSystems.getDefault().getPath(".");
-                    final Path outputPath = Files.createTempDirectory(local, "model-scaling-");
+                    final Path outputPath = Files.createTempDirectory("model-scaling-");
                     final Dataset dataset = TDBFactory.createDataset(outputPath.toString());
                     model = dataset.getDefaultModel();
                 } catch (Exception e) {

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -19,8 +19,7 @@ import org.apache.jena.vocabulary.XSD;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.util.*;
 
 import static com.ncc.aif.AIFUtils.*;
@@ -357,11 +356,16 @@ public class ScalingTest {
                 break;
 
             case TDB:
-                // Make a disk model
-                String tempDir = System.getProperty("java.io.tmpdir");
-                String tempLoc = tempDir + File.separator + "model-scaling-" + UUID.randomUUID();
-                Dataset dataset = TDBFactory.createDataset(tempLoc);
-                model = dataset.getDefaultModel();
+                try {
+                    // Make a disk model
+                    final Path local = FileSystems.getDefault().getPath(".");
+                    final Path outputPath = Files.createTempDirectory(local, "model-scaling-");
+                    final Dataset dataset = TDBFactory.createDataset(outputPath.toString());
+                    model = dataset.getDefaultModel();
+                } catch (Exception e) {
+                    System.err.println("Unable to create temp directory: " + e.getMessage());
+                    e.printStackTrace();
+                }
                 break;
 
             default:

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -120,7 +120,7 @@ public class ScalingTest {
     // Set this to no perform scaling, but rather try different output formats
     private boolean useMultipleOutputs = false;
 
-    // Set this to true to run multiple, scaling tests, or false to run a single unscaled test
+    // Set this to false to run a single, unscaled test
     private boolean runScalingTest = true;
 
     /**
@@ -135,7 +135,6 @@ public class ScalingTest {
     }
 
     private void parseArgs(List<String> args) {
-
         if (args.contains("-o")) {
             useMultipleOutputs = true;
             runScalingTest = false;
@@ -161,11 +160,9 @@ public class ScalingTest {
             System.err.println("Cannot perform validation on multiple output type tests.");
             System.exit(1);
         }
-
     }
 
     private void runTest() {
-
         if (useMultipleOutputs) {
             runOneTest();
             dumpMultipleFormats();
@@ -177,7 +174,6 @@ public class ScalingTest {
     }
 
     private void runScalingTest() {
-
         for (int ii = 0; ii < 200; ii++) {
             runSingleTest();
             entityCount *= 2;
@@ -190,18 +186,17 @@ public class ScalingTest {
         long startTime = System.currentTimeMillis();
 
         runOneTest();
-
         dumpAndAssertValid();
 
         long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Convert from milliseconds to seconds.
+        long duration = (endTime - startTime) / 1000; // Convert from milliseconds to seconds.
 
         long size = 0;
         File f = new File(filename);
         if (f.exists()) {
             size = f.length();
         }
-        size /= 1000000.;      // Convert from bytes to megabytes.
+        size /= 1000000.; // Convert from bytes to megabytes.
         System.out.println(" Size of output (mb): " + size + "  Time (sec): " + duration);
     }
 
@@ -227,7 +222,6 @@ public class ScalingTest {
     }
 
     private void addEntity() {
-
         // Add an entity
         Resource entityResource = makeEntity(model, getEntityUri(), system);
         entityResourceList.add(entityResource);
@@ -326,8 +320,6 @@ public class ScalingTest {
     // we dump the test name and the model in Turtle format so that whenever the user
     // runs the tests, they will also get the examples
     private void dumpAndAssertValid() {
-
-
         try {
             RDFDataMgr.write(Files.newOutputStream(Paths.get(filename)), model, RDFFormat.TURTLE_PRETTY);
             if (performValidation) {
@@ -344,7 +336,6 @@ public class ScalingTest {
      * Try all the different types of output types.
      */
     private void dumpMultipleFormats() {
-
         for (RDFFormat trialFormat : outputFormats) {
             String outputFilename = filename + "." + trialFormat.toString();
             outputFilename = outputFilename.replace(" ", "").replace("/", "_");
@@ -356,7 +347,6 @@ public class ScalingTest {
             }
         }
     }
-
 
     private void createModel() {
 
@@ -428,7 +418,6 @@ public class ScalingTest {
         s += randomChar();
         return s;
     }
-
 
     private String getRandomString(int length) {
         StringBuilder s = new StringBuilder();


### PR DESCRIPTION
Changes for [AIDA-554](https://nextcentury.atlassian.net/browse/AIDA-554):
- Removed reference to an undefined rule from AIF (this cased `pySHACL` to report an invalid shape);
- Added loaded imports to Data Graph (file to be validated)-- this was required in some cases for Jena to load the KB;
- Fixed the AIF `ScalingTest` to generate valid (unrestricted) AIF;
- Added functionality to the AIF `ScalingTest` so that it can generate (and optionally validate) arbitrarily large KBs.
- Wrote an associated [Confluence page](https://nextcentury.atlassian.net/wiki/spaces/AIDA/pages/510558318/AIF+Validator+Performance) with embedded Excel file to show validator timing results.

To test this PR, consider exercising the `ScalingTest` and running some generated KBs against the AIF Validator.  Depending on your machine, your times may deviate from mine but will presumably be lower than HAL 2.0.  The other files used for validation that are referred to in the spreadsheet can be made available.

If finding any valid restricted AIF examples for performance or other testing becomes problematic, then perhaps the `ScalingTest` will be updated with the capability (optionally) to generated restricted AIF.