### PR TITLE
Aida 645

### DIFF
--- a/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/src/main/java/com/ncc/aif/AIFUtils.java
@@ -907,6 +907,16 @@ public class AIFUtils {
     }
 
     /**
+     *  Mark [entity] as having the specified [importance] value.
+     *
+     * @param entity     The Resource to mark with the specified importance
+     * @param importance The importance value with which to mark the specified Resource
+     */
+    public static void markImportance(Resource entity, Integer importance) {
+        entity.addLiteral(AidaAnnotationOntology.IMPORTANCE_PROPERTY, importance);
+    }
+
+    /**
      * Mark an argument as depending on a hypothesis.
      *
      * @param depender   the argument that depends on the specified hypothesis

--- a/src/main/java/com/ncc/aif/AidaAnnotationOntology.java
+++ b/src/main/java/com/ncc/aif/AidaAnnotationOntology.java
@@ -16,6 +16,7 @@ public final class AidaAnnotationOntology {
     public static final Property NAME_PROPERTY = ResourceFactory.createProperty(NAMESPACE + "hasName");
     public static final Property TEXT_VALUE_PROPERTY = ResourceFactory.createProperty(NAMESPACE + "textValue");
     public static final Property NUMERIC_VALUE_PROPERTY = ResourceFactory.createProperty(NAMESPACE + "numericValue");
+    public static final Property IMPORTANCE_PROPERTY = ResourceFactory.createProperty(NAMESPACE + "importance");
     public static final Property CONFIDENCE = ResourceFactory.createProperty(NAMESPACE + "confidence");
     public static final Property CONFIDENCE_VALUE = ResourceFactory.createProperty(NAMESPACE + "confidenceValue");
     public static final Property JUSTIFIED_BY = ResourceFactory.createProperty(NAMESPACE + "justifiedBy");

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -201,6 +201,9 @@ aida:EventArgumentShape
   # may provide a confidence
   sh:property aida:ConfidencePropertyShape ;
 
+  # may provide an importance
+  sh:property aida:ImportancePropertyShape .
+
   # may provide an one or more source systems
   sh:property aida:SystemPropertyShape ;
 
@@ -255,6 +258,9 @@ aida:RelationArgumentShape
 
   # may provide a confidence
   sh:property aida:ConfidencePropertyShape ;
+
+  # may provide an importance
+  sh:property aida:ImportancePropertyShape .
 
   # may provide an one or more source systems
   sh:property aida:SystemPropertyShape ;
@@ -1043,10 +1049,7 @@ aida:RdfStatementShape
             aida:EventArgumentSubclass
             aida:RelationArgumentSubclass ) ;
         sh:message "All rdf:Statements must be type declarations or have predicates from the domain relation or event argument types. This error is often caused by using a value outside the domain ontology"
-    ] ;
-
-    # may provide a importance
-    sh:property aida:ImportancePropertyShape .
+    ] .
 
 # Sometimes there is uncertainty about whether or not two entities or events are the same.
 # In such cases, we make "cluster" objects which can link together the possibly identical
@@ -1067,7 +1070,7 @@ aida:ClusterShape
       sh:minCount 1 ;
       sh:maxCount 1  ] ;
 
-   # may provide a importance
+   # may provide an importance
    sh:property aida:ImportancePropertyShape ;
 
    # may provide an one or more source systems
@@ -1243,7 +1246,7 @@ aida:HypothesisShape
     # a hypothesis can specify confidence
     sh:property aida:ConfidencePropertyShape ;
 
-    # may provide a importance
+    # may provide an importance
     sh:property aida:ImportancePropertyShape ;
 
     sh:property aida:SystemPropertyShape ;

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -1217,6 +1217,11 @@ aida:MutualExclusionAlternativeShape
     sh:ignoredProperties ( rdf:type )
     .
 
+aida:ImportancePropertyShape
+  a sh:PropertyShape ;
+  sh:path aida:importance ;
+  sh:datatype xsd:int .
+
 aida:HypothesisShape
     a sh:NodeShape ;
     sh:targetClass aida:Hypothesis ;
@@ -1232,6 +1237,9 @@ aida:HypothesisShape
 
     # a hypothesis can specify confidence
     sh:property aida:ConfidencePropertyShape ;
+
+    # may provide a importance
+    sh:property aida:ImportancePropertyShape ;
 
     sh:property aida:SystemPropertyShape ;
 

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -202,7 +202,7 @@ aida:EventArgumentShape
   sh:property aida:ConfidencePropertyShape ;
 
   # may provide an importance
-  sh:property aida:ImportancePropertyShape .
+  sh:property aida:ImportancePropertyShape ;
 
   # may provide an one or more source systems
   sh:property aida:SystemPropertyShape ;
@@ -260,7 +260,7 @@ aida:RelationArgumentShape
   sh:property aida:ConfidencePropertyShape ;
 
   # may provide an importance
-  sh:property aida:ImportancePropertyShape .
+  sh:property aida:ImportancePropertyShape ;
 
   # may provide an one or more source systems
   sh:property aida:SystemPropertyShape ;

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -1043,8 +1043,10 @@ aida:RdfStatementShape
             aida:EventArgumentSubclass
             aida:RelationArgumentSubclass ) ;
         sh:message "All rdf:Statements must be type declarations or have predicates from the domain relation or event argument types. This error is often caused by using a value outside the domain ontology"
-    ]
-    .
+    ] ;
+
+    # may provide a importance
+    sh:property aida:ImportancePropertyShape .
 
 # Sometimes there is uncertainty about whether or not two entities or events are the same.
 # In such cases, we make "cluster" objects which can link together the possibly identical
@@ -1064,6 +1066,9 @@ aida:ClusterShape
                 [sh:class aida:Relation] ) ;
       sh:minCount 1 ;
       sh:maxCount 1  ] ;
+
+   # may provide a importance
+   sh:property aida:ImportancePropertyShape ;
 
    # may provide an one or more source systems
    sh:property aida:SystemPropertyShape ;

--- a/src/main/resources/edu/isi/gaia/InterchangeOntology
+++ b/src/main/resources/edu/isi/gaia/InterchangeOntology
@@ -156,7 +156,7 @@
   rdfs:subPropertyOf owl:topDataProperty ; .
 
 :importance rdf:type owl:DatatypeProperty ;
-  rdfs:comment "Confidence instances might have numerical values associated with them, such as probabilities or likliehoods." ;
+  rdfs:comment "Value for importance represented as an integer." ;
   rdfs:domain [
         rdf:type owl:Class ;
         owl:unionOf (
@@ -177,7 +177,6 @@
             :Event
             :SameAsCluster ) ] ;
   rdfs:subPropertyOf owl:topObjectProperty ; .
-
 :prototype rdf:type owl:ObjectProperty ;
   rdfs:label "prototypical member" ;
   rdfs:domain :SameAsCluster ;

--- a/src/main/resources/edu/isi/gaia/InterchangeOntology
+++ b/src/main/resources/edu/isi/gaia/InterchangeOntology
@@ -155,6 +155,18 @@
   rdfs:range xsd:float ;
   rdfs:subPropertyOf owl:topDataProperty ; .
 
+:importance rdf:type owl:DatatypeProperty ;
+  rdfs:comment "Confidence instances might have numerical values associated with them, such as probabilities or likliehoods." ;
+  rdfs:domain [
+        rdf:type owl:Class ;
+        owl:unionOf (
+            :rdf:Statement
+            :Hypothesis
+            :SameAsCluster ) ] ;
+  rdfs:label "importance" ;
+  rdfs:range xsd:int ;
+  rdfs:subPropertyOf owl:topDataProperty ; .
+
 :clusterMember rdf:type owl:ObjectProperty ;
   rdfs:label "cluster member" ;
   rdfs:domain :ClusterMembership ;

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -455,6 +455,57 @@ public class ExamplesAndValidationTest {
             assertAndDump(model, "simple hypothesis with cluster", seedlingValidator, true);
         }
 
+        // Create simple hypothesis with an importance value where the BUK weapon system was owned by Russia
+        @Test
+        void simpleHypothesisWithImportanceWithCluster() {
+
+            final Model model = createModel();
+
+            // every AIF needs an object for the system responsible for creating it
+            final Resource system = makeSystemWithURI(model, getTestSystemUri());
+
+            // buk document entity
+            final Resource buk = makeEntity(model, bukDocumentEntityUri, system);
+            final Resource bukIsWeapon = markType(model, getAssertionUri(), buk, SeedlingOntology.Weapon,
+                    system, 1.0);
+
+            // buk cross-document entity
+            final Resource bukKBEntity = makeEntity(model, bukKBEntityUri, system);
+            final Resource bukKBIsWeapon = markType(model, getAssertionUri(), bukKBEntity, SeedlingOntology.Weapon,
+                    system, 1.0);
+
+            // russia document entity
+            final Resource russia = makeEntity(model, russiaDocumentEntityUri, system);
+            final Resource russiaIsGPE = markType(model, getAssertionUri(), russia, SeedlingOntology.GeopoliticalEntity,
+                    system, 1.0);
+
+            // cluster buk
+            final Resource bukCluster = makeClusterWithPrototype(model, getClusterUri(), bukKBEntity, system);
+            final Resource bukIsClustered = markAsPossibleClusterMember(model, buk, bukCluster, .9, system);
+
+            // Russia owns buk relation
+            final Resource bukIsRussian = makeRelation(model, russiaOwnsBukDocumentRelationUri, system);
+            markType(model, getAssertionUri(), bukIsRussian, SeedlingOntology.GeneralAffiliation_APORA,
+                    system, 1.0);
+            final Resource bukArgument = markAsArgument(model, bukIsRussian,
+                    SeedlingOntology.GeneralAffiliation_APORA_Affiliate, buk, system, 1.0);
+            final Resource russiaArgument = markAsArgument(model, bukIsRussian,
+                    SeedlingOntology.GeneralAffiliation_APORA_Affiliation, russia, system, 1.0);
+
+            // Russia owns buk hypothesis
+            final Resource bukIsRussianHypothesis = makeHypothesis(model, getUri("hypothesis-1"),
+                    ImmutableSet.of(
+                            buk, bukIsWeapon, bukIsClustered,
+                            russia, russiaIsGPE,
+                            bukIsRussian, bukArgument, russiaArgument
+                    ), system);
+
+            markImportance(bukIsRussianHypothesis, 102); //add importance of 102
+
+            assertAndDump(model, "simple hypothesis with importance with cluster",
+                    seedlingValidator, true);
+        }
+
         @Test
         void createSeedlingEntityOfTypePersonWithImageJustificationAndVector() {
             final Model model = createModel();


### PR DESCRIPTION
- Updated AIFUtils to include new  markImportance() method
- Updated AidaAnnotationOntology to include new IMPORTANCE_PROPERTY 
- Added ability to add importance to Hypothesis, Cluster, and RdfStatement Shape in the aida_ontology.shacl
- Updated InterchangeOntology to include definition of importance 
- Created simpleHypothesisWithImportanceWithCluster to test adding importance to a hypothesis.