### PR TITLE
AIDA-668

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -15,8 +15,9 @@
 aida:EdgeJustificationLimit
     a sh:PropertyShape ;
     sh:path ( aida:justifiedBy aida:containedJustification ) ;
+    sh:minCount 1 ;
     sh:maxCount 2 ;
-    sh:message "Only 2 contained justifications allowed for an edge" .
+    sh:message "Only 1 or 2 contained justifications allowed for an edge" .
 
 # Turn off CompoundJustificationMinimum globally
 aida:CompoundJustificationMinimum sh:deactivated true .
@@ -124,18 +125,3 @@ aida:RelationMustBeClustered
             }
         """ ;
     ] .
-
-#########################
-# A justification for an AIF argument assertion must have either one or two spans and must be represented
-# by aida:CompoundJustification, even if only one span is provided.
-#------------------------
-aida:CompoundJustificationShape
-   a sh:NodeShape ;
-   sh:targetClass aida:CompoundJustification ;
-
-   # must have either one or two contained justifications of specified types
-   sh:property [
-        sh:path aida:containedJustification ;
-        sh:minCount 1 ;
-        sh:maxCount 2 ] ;
-   sh:message "CompoundJustification for an AIF argument assertion must have either one or two spans" .

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -124,3 +124,18 @@ aida:RelationMustBeClustered
             }
         """ ;
     ] .
+
+#########################
+# A justification for an AIF argument assertion must have either one or two spans and must be represented
+# by aida:CompoundJustification, even if only one span is provided.
+#------------------------
+aida:CompoundJustificationShape
+   a sh:NodeShape ;
+   sh:targetClass aida:CompoundJustification ;
+
+   # must have either one or two contained justifications of specified types
+   sh:property [
+        sh:path aida:containedJustification ;
+        sh:minCount 1 ;
+        sh:maxCount 2 ] ;
+   sh:message "CompoundJustification for an AIF argument assertion must have either one or two spans" .

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1298,16 +1298,22 @@ public class ExamplesAndValidationTest {
                         ImmutableSet.of(justification1, justification2, justification3),
                         system,
                         1d);
+                final Resource emptyCompound = markCompoundJustification(model,
+                        ImmutableSet.of(relationEdge),
+                        ImmutableSet.of(),
+                        system,
+                        1d);
 
                 // test event
                 final Resource eventEdge = markAsArgument(model, event, SeedlingOntology.Conflict_Attack_Target, entity,
                         system, 1.0, getAssertionUri());
                 markJustification(eventEdge, compound);
+                markJustification(eventEdge, emptyCompound);
 
                 assertAndDump(model, "NIST.invalid: edge justification contains at most two mentions",
-                        nistSeedlingValidator, false);
+                        nistSeedlingValidator, true);
             }
-            
+
             @Test
             void valid() {
                 // test relation

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1274,7 +1274,7 @@ public class ExamplesAndValidationTest {
             }
         }
 
-        // Each edge justification is limited to two or fewer spans
+        // Each edge justification is limited to either one or two spans.
         @Nested
         class EdgeJustificationLimit {
             @Test
@@ -1303,6 +1303,7 @@ public class ExamplesAndValidationTest {
                         nistSeedlingValidator, false);
             }
 
+
             @Test
             void valid() {
                 // test relation
@@ -1316,6 +1317,29 @@ public class ExamplesAndValidationTest {
                 final Resource compound = markCompoundJustification(model,
                         ImmutableSet.of(relationEdge),
                         ImmutableSet.of(justification1, justification2),
+                        system,
+                        1d);
+
+                // test event
+                final Resource eventEdge = markAsArgument(model, event, SeedlingOntology.Conflict_Attack_Target, entity, system, 1.0);
+                markJustification(eventEdge, compound);
+
+                assertAndDump(model, "NIST.valid: edge justification contains at most two mentions",
+                        nistSeedlingValidator, true);
+            }
+
+            @Test
+            void validOneSpan() {
+                // test relation
+                final Resource relation = makeRelation(model, getUri("relationX"), system);
+                addType(relation, SeedlingOntology.GeneralAffiliation_APORA);
+                makeClusterWithPrototype(model, getClusterUri(), relation, system);
+                final Resource relationEdge = markAsArgument(model, relation,
+                        SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d);
+                final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
+                final Resource compound = markCompoundJustification(model,
+                        ImmutableSet.of(relationEdge),
+                        ImmutableSet.of(justification1),
                         system,
                         1d);
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1302,8 +1302,7 @@ public class ExamplesAndValidationTest {
                 assertAndDump(model, "NIST.invalid: edge justification contains at most two mentions",
                         nistSeedlingValidator, false);
             }
-
-
+            
             @Test
             void valid() {
                 // test relation


### PR DESCRIPTION
- Created new restricted AIF rule to allow an assertion to only have one or two CompoundJustification spans
- Created new test that creates an assertion with only one CompoundJustification span.