### PR TITLE
Aida 667: type assertions must be justified

### DIFF
--- a/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/src/main/java/com/ncc/aif/AIFUtils.java
@@ -9,7 +9,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.SKOS;
 import org.apache.jena.vocabulary.XSD;
 
 import javax.annotation.Nullable;
@@ -36,7 +35,6 @@ public class AIFUtils {
         model.setNsPrefix("rdf", RDF.uri);
         model.setNsPrefix("xsd", XSD.getURI());
         model.setNsPrefix("aida", AidaAnnotationOntology.NAMESPACE);
-        model.setNsPrefix("skos", SKOS.uri);
     }
 
     /**

--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -440,6 +440,7 @@ public final class ValidateAIF {
         // This is required so that constraints like "the object of a type must be an
         // entity type" will know what types are in fact entity types.
         final Model unionModel = (union == null) ? ModelFactory.createUnion(domainModel, dataToBeValidated) : union;
+        unionModel.setNsPrefix("sh", "http://www.w3.org/ns/shacl#");
 
         // Apply appropriate shacl restrictions
         Model shacl;

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -453,6 +453,20 @@ aida:RelationArgumentSubclass
 aida:SharedTypeShape
     a sh:NodeShape ;
 
+    # this shape applies when the predicate of the RDF statement is rdf:type
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
+            SELECT ?this
+            WHERE {
+                ?this a rdf:Statement .
+                ?this rdf:predicate rdf:type .
+            }
+        """
+    ] ;
+
     # may provide a confidence
     sh:property aida:ConfidencePropertyShape ;
 
@@ -490,15 +504,10 @@ aida:EntityTypeShape
             }
         """
     ] ;
-    sh:and (
-        aida:SharedTypeShape
-        [
-            sh:property [
-                sh:path rdf:object ;
-                sh:property aida:EntitySubclass
-            ]
-        ]
-    ) ;
+    sh:property [
+        sh:path rdf:object ;
+        sh:property aida:EntitySubclass
+    ] ;
     sh:message "Cannot assign a non-Entity type to an Entity"
     .
 
@@ -519,15 +528,10 @@ aida:EventTypeShape
             }
         """
     ] ;
-    sh:and (
-        aida:SharedTypeShape
-        [
-            sh:property [
-                sh:path rdf:object ;
-                sh:property aida:EventSubclass
-            ]
-        ]
-    ) ;
+    sh:property [
+        sh:path rdf:object ;
+        sh:property aida:EventSubclass
+    ] ;
     sh:message "Cannot assign a non-Event type to an Event"
     .
 
@@ -548,15 +552,10 @@ aida:RelationTypeShape
             }
         """
     ] ;
-    sh:and (
-        aida:SharedTypeShape
-        [
-            sh:property [
-                sh:path rdf:object ;
-                sh:property aida:RelationSubclass
-            ]
-        ]
-    ) ;
+    sh:property [
+        sh:path rdf:object ;
+        sh:property aida:RelationSubclass
+    ] ;
     sh:message "Cannot assign a non-Relation type to a Relation"
     .
 

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -17,7 +17,7 @@ aida:EdgeJustificationLimit
     sh:path ( aida:justifiedBy aida:containedJustification ) ;
     sh:minCount 1 ;
     sh:maxCount 2 ;
-    sh:message "Only 1 or 2 contained justifications allowed for an edge" .
+    sh:message "Exactly 1 or 2 contained justifications required for an edge" .
 
 # Turn off CompoundJustificationMinimum globally
 aida:CompoundJustificationMinimum sh:deactivated true .
@@ -185,3 +185,23 @@ aida:ConfidenceValueRange
         sh:maxInclusive 1;
         sh:message "Confidence value must be between 0 and 1"]
     .
+
+#########################
+# Each entity/relation/event type statement must have at least one justification
+#------------------------
+aida:EntityTypeShape
+	sh:property aida:RequiredJustificationPropertyShape .
+
+aida:EventTypeShape
+	sh:property aida:RequiredJustificationPropertyShape .
+
+aida:RelationTypeShape
+	sh:property aida:RequiredJustificationPropertyShape .
+
+# Use this instead of aida:JustificationPropertyShape when you wish to force justifications to be present
+aida:RequiredJustificationPropertyShape
+   a sh:PropertyShape ;
+   sh:path aida:justifiedBy ;
+   sh:propertyShape aida:JustificationPropertyShape ;
+   sh:minCount 1 ;
+   sh:message "Type assertions must have at least one justification" .

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -12,14 +12,21 @@
 # Each edge justification is limited to one or two spans
 #------------------------
 # Can have 1 or 2 containedJustification properties
-aida:CompoundJustificationShape
-    sh:property [
-        a sh:PropertyShape ;
-        sh:path aida:containedJustification ;
-        sh:minCount 1 ;
-        sh:maxCount 2 ;
-        sh:message "Exactly 1 or 2 contained justifications required for an edge"
-    ] .
+aida:EdgeJustificationCount
+    a sh:SPARQLConstraint ;
+    sh:message "Exactly 1 or 2 contained justifications required for an edge" ;
+    sh:select """
+        PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
+        SELECT $this (COUNT(DISTINCT ?source) AS $value)
+        WHERE {
+            $this aida:justifiedBy ?x .
+            ?x a aida:CompoundJustification .
+            OPTIONAL { ?x aida:containedJustification ?source }
+        }
+        GROUP BY $this ?x
+        HAVING (COUNT(?source) > 2 || COUNT(?source) < 1)
+    """
+    .
 
 # Turn off CompoundJustificationMinimum globally
 aida:CompoundJustificationMinimum sh:deactivated true .
@@ -36,11 +43,15 @@ aida:EdgeJustificationCompound
     sh:class aida:CompoundJustification ;
     sh:message "Edge justification must be of type aida:CompoundJustification" .
 
-# Enforce edge justification restriction on event and relation arguments
+# Enforce edge justification restrictions on event and relation arguments
 aida:EventArgumentShape
-    sh:property aida:EdgeJustificationCompound .
+    sh:property aida:EdgeJustificationCompound ;
+    sh:sparql aida:EdgeJustificationCount
+    .
 aida:RelationArgumentShape
-    sh:property aida:EdgeJustificationCompound .
+    sh:property aida:EdgeJustificationCompound ;
+    sh:sparql aida:EdgeJustificationCount
+    .
 
 #########################
 # CompoundJustification must be used only for justifications of argument assertions,
@@ -191,13 +202,7 @@ aida:ConfidenceValueRange
 #########################
 # Each entity/relation/event type statement must have at least one justification
 #------------------------
-aida:EntityTypeShape
-	sh:property aida:RequiredJustificationPropertyShape .
-
-aida:EventTypeShape
-	sh:property aida:RequiredJustificationPropertyShape .
-
-aida:RelationTypeShape
+aida:SharedTypeShape
 	sh:property aida:RequiredJustificationPropertyShape .
 
 # Use this instead of aida:JustificationPropertyShape when you wish to force justifications to be present

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -9,15 +9,17 @@
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 
 #########################
-# Each edge justification is limited to two or fewer spans
+# Each edge justification is limited to one or two spans
 #------------------------
-# Can have a maximum of 2 justifiedBy/containedJustification properties
-aida:EdgeJustificationLimit
-    a sh:PropertyShape ;
-    sh:path ( aida:justifiedBy aida:containedJustification ) ;
-    sh:minCount 1 ;
-    sh:maxCount 2 ;
-    sh:message "Exactly 1 or 2 contained justifications required for an edge" .
+# Can have 1 or 2 containedJustification properties
+aida:CompoundJustificationShape
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path aida:containedJustification ;
+        sh:minCount 1 ;
+        sh:maxCount 2 ;
+        sh:message "Exactly 1 or 2 contained justifications required for an edge"
+    ] .
 
 # Turn off CompoundJustificationMinimum globally
 aida:CompoundJustificationMinimum sh:deactivated true .
@@ -36,9 +38,9 @@ aida:EdgeJustificationCompound
 
 # Enforce edge justification restriction on event and relation arguments
 aida:EventArgumentShape
-    sh:property aida:EdgeJustificationCompound, aida:EdgeJustificationLimit .
+    sh:property aida:EdgeJustificationCompound .
 aida:RelationArgumentShape
-    sh:property aida:EdgeJustificationCompound, aida:EdgeJustificationLimit .
+    sh:property aida:EdgeJustificationCompound .
 
 #########################
 # CompoundJustification must be used only for justifications of argument assertions,

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -114,7 +114,10 @@ public class ExamplesAndValidationTest {
 
     @Nested
     class ValidExamples {
-        ValidExamples() { validator = seedlingValidator; }
+        ValidExamples() {
+            validator = seedlingValidator;
+        }
+
         private final String putinDocumentEntityUri = getUri("E781167.00398");
         private final String putinResidesDocumentRelationUri = getUri("R779959.00000");
         private final String putinElectedDocumentEventUri = getUri("V779961.00010");
@@ -1021,7 +1024,10 @@ public class ExamplesAndValidationTest {
      */
     @Nested
     class InvalidExamples {
-        InvalidExamples() { validator = seedlingValidator; }
+        InvalidExamples() {
+            validator = seedlingValidator;
+        }
+
         @Test
         void entityMissingType() {
             // having multiple type assertions in case of uncertainty is ok, but there must always
@@ -1109,7 +1115,9 @@ public class ExamplesAndValidationTest {
         Resource relationCluster;
         Resource typeAssertionJustification; // For use when tests create their own entities, events, and relations
 
-        NISTExamples() { validator = nistSeedlingValidator; }
+        NISTExamples() {
+            validator = nistSeedlingValidator;
+        }
 
         @BeforeEach
         void setup() {
@@ -1314,7 +1322,7 @@ public class ExamplesAndValidationTest {
                 final Resource newEvent = makeEvent(model, getUri("eventX"), system);
                 markJustification(addType(newEvent, SeedlingOntology.Life_BeBorn), typeAssertionJustification);
 
-                testInvalid( "NIST.invalid: Everything has cluster");
+                testInvalid("NIST.invalid: Everything has cluster");
             }
 
             @Test
@@ -1336,6 +1344,7 @@ public class ExamplesAndValidationTest {
                 markAsPossibleClusterMember(model, newEntity, entityCluster, 1.2, system);
                 testInvalid("NIST.invalid: confidence must be between 0 and 1");
             }
+
             @Test
             void valid() {
                 final Resource newEntity = makeEntity(model, getEntityUri(), system);
@@ -1408,7 +1417,10 @@ public class ExamplesAndValidationTest {
     class NISTHypothesisExamples {
         Resource entity;
         Resource entityCluster;
-        NISTHypothesisExamples() { validator = nistSeedlingHypothesisValidator; }
+
+        NISTHypothesisExamples() {
+            validator = nistSeedlingHypothesisValidator;
+        }
 
         @BeforeEach
         void setup() {
@@ -1446,6 +1458,7 @@ public class ExamplesAndValidationTest {
      * This method will validate the model using the provided validator and will dump the model as TURTLE if
      * either the validation result is unexpected or if the model is valid and FORCE_DUMP is true. Thus, FORCE_DUMP
      * can be used to write all the valid examples to console.
+     *
      * @param model     {@link Model} containing the triples to be validated
      * @param testName  {@link String} containing the name of the test
      * @param validator {@link ValidateAIF} object used to validate {@code model}

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1322,7 +1322,7 @@ public class ExamplesAndValidationTest {
 
             @Test
             void valid() {
-                // setup() already already creates an entity, event, and relation
+                // setup() already creates an entity, event, and relation
                 // object, and adds them to a cluster.
 
                 testValid("NIST.valid: Everything has cluster");
@@ -1394,7 +1394,7 @@ public class ExamplesAndValidationTest {
 
             @Test
             void valid() {
-                // setup() already already makes type assertions on the entity, event,
+                // setup() already makes type assertions on the entity, event,
                 // and relation objects, justified by a text justification.
 
                 // Note that if you use makeRelationInEventForm, you will need to use the Jena API to obtain

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1158,16 +1158,12 @@ public class ExamplesAndValidationTest {
                         entity, system, 1.0, getAssertionUri());
                 markJustification(eventEdge, justification);
 
-                // The text justification above doesn't count as a valid edge justification,
-                // so add a compound justification to the edges
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
                 final Resource compound1 = markCompoundJustification(model,
                         ImmutableSet.of(entity, relation, event),
                         ImmutableSet.of(justification1),
                         system,
                         1d);
-                markJustification(eventEdge, compound1);
-                markJustification(relationEdge, compound1);
 
                 // test that compound justification can only be used for argument assertions
                 markJustification(entity, compound1);
@@ -1199,7 +1195,6 @@ public class ExamplesAndValidationTest {
 
                 testValid("NIST.valid: CompoundJustification must be used only for justifications of argument assertions");
             }
-
         }
 
         // Each edge justification is limited to either one or two spans.
@@ -1502,7 +1497,6 @@ public class ExamplesAndValidationTest {
         }
         return outputPath;
     }
-
 
     private Model readModelFromDisk(Path filename) {
         try {


### PR DESCRIPTION
Work performed:
- Added the restriction to the restricted AIF SHACL file.
- Added `JustifyTypeAssertions` valid and invalid test to `NISTExamples`.
- Retrofitted other NIST tests (both valid and invalid) as necessary so the valid tests stayed valid and the invalid tests only failed for the "right" reasons-- the reasons that they are testing.
- Since I visited every test, in some cases I tweaked the test, most notably relying on `setup()` for the `EverythingClustered.valid()` test and I believe fixing `RestrictJustification.invalid()` so it doesn't also fail because of the "Exactly 1 or 2 contained justifications required for an edge" restriction...unless the intention was to remove the EdgeJustificationLimit class?  Please verify this action was correct.
- Did a tiny bit of cleanup.

**Note**, at one point we discussed adding the restriction to `aida:SharedTypeShape`, but when I tried that, I got "Cannot assign a non-Entity type to an Entity" non-conformances.  If there's another way not to have to add `aida:RequiredJustificationPropertyShape` to each `aida:XXXTypeShape`, then please let me know.

**Question**:  should `JustifyTypeAssertions` have another invalid test where the type assertion is justified with a `CompoundJustification`, since that is not allowed in restricted AIF (due to "CompoundJustification must be used only for justifications of argument assertions")?

To test this, ensure that the valid tests remain valid, and the invalid tests only have the non-conformances that they're designed to be demonstrating.