### PR TITLE
Aida 683

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -191,3 +191,4 @@ aida:ConfidenceValueRange
 #------------------------
 aida:NamePropertyShape
   sh:maxLength 256;
+  

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -191,4 +191,3 @@ aida:ConfidenceValueRange
 #------------------------
 aida:NamePropertyShape
   sh:maxLength 256;
-  

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -185,3 +185,9 @@ aida:ConfidenceValueRange
         sh:maxInclusive 1;
         sh:message "Confidence value must be between 0 and 1"]
     .
+
+#########################
+# Each entity/filler name string is limited to 256 UTF-8 characters
+#------------------------
+aida:NamePropertyShape
+  sh:maxLength 256;

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1374,7 +1374,7 @@ public class ExamplesAndValidationTest {
                         "fail because this string is exactly 257 characters long. This is filler text to " +
                         "get to the two hundred and fifty-seven limit.");
 
-                testValid("NIST.invalid: Each entity name string is limited to 256 UTF-8 characters");
+                testInvalid("NIST.invalid: Each entity name string is limited to 256 UTF-8 characters");
             }
 
             @Test

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1368,19 +1368,18 @@ public class ExamplesAndValidationTest {
         class NameMaxLength {
             @Test
             void invalid() {
-                // assign alternate names to the putin entity
-                final Resource newEntity = makeEntity(model, getEntityUri(), system);
-                addType(newEntity, SeedlingOntology.Person);
-                markName(newEntity, "This is a test string that will be used to validate " +
+                // assign alternate names to the entity that are longer that 256 characters.
+                markName(entity, "This is a test string that will be used to validate " +
                         "that entity names and fillers are limited to 256 characters. This string should " +
                         "fail because this string is exactly 257 characters long. This is filler text to " +
                         "get to the two hundred and fifty-seven limit.");
 
-                testInvalid("NIST.invalid: Each entity name string is limited to 256 UTF-8 characters");
+                testValid("NIST.invalid: Each entity name string is limited to 256 UTF-8 characters");
             }
 
             @Test
             void valid() {
+                // assign alternate names to the entity that are equal and less than 256 characters.
                 markName(entity, "This is a test string that will be used to validate that entity " +
                         "names and fillers are limited to 256 characters. This string should pass because " +
                         "this string is exactly 256 characters long. Characters to get to the two hundred " +

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1362,6 +1362,35 @@ public class ExamplesAndValidationTest {
                 testValid("NIST.valid: Cluster has IRI");
             }
         }
+
+        // Each entity/filler name string is limited to 256 UTF-8 characters
+        @Nested
+        class NameMaxLength {
+            @Test
+            void invalid() {
+                // assign alternate names to the putin entity
+                final Resource newEntity = makeEntity(model, getEntityUri(), system);
+                addType(newEntity, SeedlingOntology.Person);
+                markName(newEntity, "This is a test string that will be used to validate " +
+                        "that entity names and fillers are limited to 256 characters. This string should " +
+                        "fail because this string is exactly 257 characters long. This is filler text to " +
+                        "get to the two hundred and fifty-seven limit.");
+
+                testInvalid("NIST.invalid: Each entity name string is limited to 256 UTF-8 characters");
+            }
+
+            @Test
+            void valid() {
+                markName(entity, "This is a test string that will be used to validate that entity " +
+                        "names and fillers are limited to 256 characters. This string should pass because " +
+                        "this string is exactly 256 characters long. Characters to get to the two hundred " +
+                        "and fifty-six character limit.");
+
+                markName(entity, "Small string size");
+
+                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
- Created SHACL restricting NamePropertyShape to be 256 characters or less.
- Created NameMaxLength invalid / valid tests entity names must be 256 characters or less. 