### PR TITLE
AIDA 704:  Clusters must be able to contain Relations

### DIFF
--- a/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/src/main/java/com/ncc/aif/AIFUtils.java
@@ -160,7 +160,10 @@ public class AIFUtils {
      * @param system           The system object for the system which created the specified relation
      * @param confidence       If non-null, the confidence with which to mark the specified relation
      * @return The created relation resource
+     * @deprecated AIF no longer represents relations as simply a connection between two entities,
+     * so use {@link #makeRelation(Model, String, Resource)} instead
      */
+    @Deprecated
     public static Resource makeRelationInEventForm(Model model, String relationUri, Resource relationType, Resource subjectRole,
                                                    Resource subjectResource, Resource objectRole, Resource objectResource,
                                                    String typeAssertionUri, Resource system, Double confidence) {
@@ -261,7 +264,7 @@ public class AIFUtils {
 
     // Helper function to create a justification (text, image, audio, etc.) in the system.
     private static Resource makeAIFJustification(Model model, String docId, Resource classType,
-                                                Resource system, Double confidence) {
+                                                 Resource system, Double confidence) {
         final Resource justification = makeAIFResource(model, null, classType, system);
         justification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral(docId));
         markConfidence(model, justification, confidence, system);
@@ -361,8 +364,8 @@ public class AIFUtils {
     /**
      * Add a sourceDocument to a pre-existing justification
      *
-     * @param justification      A pre-existing justification resource
-     * @param sourceDocument     A string containing the source document (parent) ID
+     * @param justification  A pre-existing justification resource
+     * @param sourceDocument A string containing the source document (parent) ID
      * @return The modified justification resource
      */
     public static Resource addSourceDocumentToJustification(Resource justification, String sourceDocument) {
@@ -828,12 +831,12 @@ public class AIFUtils {
      * A same-as cluster is used to represent multiple entities which might be the same, but we
      * aren't sure. (If we were sure, they would just be a single node).
      * <p>
-     * Every cluster requires a [prototype] - an entity or event that we are <b>certain</b> is in the
+     * Every cluster requires a [prototype] - an entity, event, or relation that we are <b>certain</b> is in the
      * cluster. This also automatically adds a membership relation with the prototype with confidence 1.0.
      *
      * @param model      The underlying RDF model for the operation
      * @param clusterUri A unique String URI for the cluster
-     * @param prototype  an entity or event that we are certain is in the cluster
+     * @param prototype  an entity, event, or relation that we are certain is in the cluster
      * @param system     The system object for the system which created the specified cluster
      * @return The created cluster resource
      */
@@ -848,12 +851,12 @@ public class AIFUtils {
      * A same-as cluster is used to represent multiple entities which might be the same, but we
      * aren't sure. (If we were sure, they would just be a single node).
      * <p>
-     * Every cluster requires a [prototype] - an entity or event that we are <b>certain</b> is in the
+     * Every cluster requires a [prototype] - an entity, event, or relation that we are <b>certain</b> is in the
      * cluster. This also automatically adds a membership relation with the prototype with confidence 1.0.
      *
      * @param model      The underlying RDF model for the operation
      * @param clusterUri A unique String URI for the cluster
-     * @param prototype  an entity or event that we are certain is in the cluster
+     * @param prototype  an entity, event, or relation that we are certain is in the cluster
      * @param handle     a string describing the cluster
      * @param system     The system object for the system which created the specified cluster
      * @return The created cluster resource
@@ -943,9 +946,9 @@ public class AIFUtils {
     }
 
     /**
-     *  Mark [resource] as having the specified [importance] value.
+     * Mark [resource] as having the specified [importance] value.
      *
-     * @param resource     The Resource to mark with the specified importance
+     * @param resource   The Resource to mark with the specified importance
      * @param importance The importance value with which to mark the specified Resource
      */
     public static void markImportance(Resource resource, Integer importance) {

--- a/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/src/main/java/com/ncc/aif/AIFUtils.java
@@ -160,8 +160,8 @@ public class AIFUtils {
      * @param system           The system object for the system which created the specified relation
      * @param confidence       If non-null, the confidence with which to mark the specified relation
      * @return The created relation resource
-     * @deprecated AIF no longer represents relations as simply a connection between two entities,
-     * so use {@link #makeRelation(Model, String, Resource)} instead
+     * @deprecated This method doesn't allow the user access to the blank nodes created for type and argument assertions.
+     * Use {@link #makeRelation(Model, String, Resource)} instead
      */
     @Deprecated
     public static Resource makeRelationInEventForm(Model model, String relationUri, Resource relationType, Resource subjectRole,

--- a/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology
+++ b/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology
@@ -163,6 +163,7 @@
         owl:unionOf (
             :Entity
             :Event
+            :Relation
             :SameAsCluster ) ] ;
   rdfs:subPropertyOf owl:topObjectProperty ; .
 

--- a/src/main/resources/com/ncc/aif/ontologies/README.md
+++ b/src/main/resources/com/ncc/aif/ontologies/README.md
@@ -21,7 +21,8 @@ a hand-written source file and is not generated.
 
 ### InterchangeOntology
 
-This ontology contains the Interchange vocabulary and how the defined classes and properties may interact.
+This ontology contains the Interchange vocabulary and specifies how the defined classes and properties may interact.
+It is defined in such a way that it should be able to be used with OWL reasoners.
 
 # Domain Ontologies
 

--- a/src/main/resources/com/ncc/aif/ontologies/README.md
+++ b/src/main/resources/com/ncc/aif/ontologies/README.md
@@ -22,7 +22,7 @@ a hand-written source file and is not generated.
 ### InterchangeOntology
 
 This ontology contains the Interchange vocabulary and specifies how the defined classes and properties may interact.
-It is defined in such a way that it should be able to be used with OWL reasoners.
+It is defined using strict OWL and should be able to be used with OWL reasoners.
 
 # Domain Ontologies
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -201,8 +201,8 @@ public class ExamplesAndValidationTest {
 
         @Test
         void createARelationBetweenTwoSeedlingEntitiesWhereThereIsUncertaintyAboutIdentityOfOneArgument() {
-            // we want to represent a "city_of_birth" relation for a person, but we aren't sure whether
-            // they were born in Louisville or Cambridge
+            // we want to represent a "physical_resident" relation for a person, but we aren't sure whether
+            // they reside in Russia or Ukraine
             final Resource personEntity = makeEntity(model, putinDocumentEntityUri, system);
             markType(model, getAssertionUri(), personEntity, SeedlingOntology.Person, system, 1.0);
 
@@ -213,23 +213,22 @@ public class ExamplesAndValidationTest {
             final Resource ukraineDocumentEntity = makeEntity(model, russiaDocumentEntityUri, system);
             markType(model, getAssertionUri(), ukraineDocumentEntity, SeedlingOntology.GeopoliticalEntity, system, 1.0);
 
-            // create an entity for the uncertain place of birth
+            // create an entity for the uncertain place of residence
             final Resource uncertainPlaceOfResidenceEntity = makeEntity(model, getEntityUri(), system);
             markType(model, getAssertionUri(), uncertainPlaceOfResidenceEntity, SeedlingOntology.GeopoliticalEntity, system, 1d);
 
             // whatever this place turns out to refer to, we're sure it's where they live
-            makeRelationInEventForm(model, putinResidesDocumentRelationUri,
-                    SeedlingOntology.Physical_Resident,
-                    SeedlingOntology.Physical_Resident_Resident, personEntity,
-                    SeedlingOntology.Physical_Resident_Place, uncertainPlaceOfResidenceEntity,
-                    getAssertionUri(), system, 1.0);
+            final Resource relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+            markType(model, getAssertionUri(), relation, SeedlingOntology.Physical_Resident, system, 1.0);
+            markAsArgument(model, relation, SeedlingOntology.Physical_Resident_Resident, personEntity, system, 1.0);
+            markAsArgument(model, relation, SeedlingOntology.Physical_Resident_Place, uncertainPlaceOfResidenceEntity, system, 1.0);
 
             // we use clusters to represent uncertainty about identity
             // we make two clusters, one for Russia and one for Ukraine
             final Resource russiaCluster = makeClusterWithPrototype(model, getClusterUri(), russiaDocumentEntity, system);
             final Resource ukraineCluster = makeClusterWithPrototype(model, getClusterUri(), ukraineDocumentEntity, system);
 
-            // the uncertain place of birth is either Louisville or Cambridge
+            // the uncertain place of residence is either Russia or Ukraine
             final Resource placeOfResidenceInRussiaCluster = markAsPossibleClusterMember(model,
                     uncertainPlaceOfResidenceEntity, russiaCluster, 0.4, system);
             final Resource placeOfResidenceInUkraineCluster = markAsPossibleClusterMember(model,
@@ -369,11 +368,10 @@ public class ExamplesAndValidationTest {
             final Resource isAttacker = SeedlingOntology.Conflict_Attack_Attacker;
 
             // under the background hypothesis that the BUK is Russian, we believe Russia attacked MH17
-            final Resource bukIsRussian = makeRelationInEventForm(model, russiaOwnsBukDocumentRelationUri,
-                    SeedlingOntology.GeneralAffiliation_APORA,
-                    SeedlingOntology.GeneralAffiliation_APORA_Affiliate, buk,
-                    SeedlingOntology.GeneralAffiliation_APORA_Affiliation, russia,
-                    getAssertionUri(), system, 1.0);
+            final Resource bukIsRussian = makeRelation(model, russiaOwnsBukDocumentRelationUri, system);
+            markType(model, getAssertionUri(), bukIsRussian, SeedlingOntology.GeneralAffiliation_APORA, system, 1.0);
+            markAsArgument(model, bukIsRussian, SeedlingOntology.GeneralAffiliation_APORA_Affiliate, buk, system, 1.0);
+            markAsArgument(model, bukIsRussian, SeedlingOntology.GeneralAffiliation_APORA_Affiliation, russia, system, 1.0);
 
             final Resource bukIsRussianHypothesis = makeHypothesis(model, getUri("hypothesis-1"),
                     ImmutableSet.of(bukIsRussian), system);
@@ -382,11 +380,10 @@ public class ExamplesAndValidationTest {
             markConfidence(model, bukIsRussianHypothesis, 0.75, system);
 
             // under the background hypothesis that BUK is Ukrainian, we believe Ukraine attacked MH17
-            final Resource bukIsUkrainian = makeRelationInEventForm(model, ukraineOwnsBukDocumentRelationUri,
-                    SeedlingOntology.GeneralAffiliation_APORA,
-                    SeedlingOntology.GeneralAffiliation_APORA_Affiliate, buk,
-                    SeedlingOntology.GeneralAffiliation_APORA_Affiliation, ukraine,
-                    getAssertionUri(), system, 1.0);
+            final Resource bukIsUkrainian = makeRelation(model, ukraineOwnsBukDocumentRelationUri, system);
+            markType(model, getAssertionUri(), bukIsUkrainian, SeedlingOntology.GeneralAffiliation_APORA, system, 1.0);
+            markAsArgument(model, bukIsUkrainian, SeedlingOntology.GeneralAffiliation_APORA_Affiliate, buk, system, 1.0);
+            markAsArgument(model, bukIsUkrainian, SeedlingOntology.GeneralAffiliation_APORA_Affiliation, ukraine, system, 1.0);
 
             final Resource bukIsUkranianHypothesis = makeHypothesis(model, getUri("hypothesis-2"),
                     ImmutableSet.of(bukIsUkrainian), 0.25, system);
@@ -858,12 +855,11 @@ public class ExamplesAndValidationTest {
 
             // relation that President Obama (of uncertain reference) worked with Secretary Clinton (of uncertain reference)
             // is asserted in document 2
-            final Resource relation = makeRelationInEventForm(model, getUri("relation-1"),
-                    SeedlingOntology.PersonalSocial_Business,
-                    SeedlingOntology.PersonalSocial_Business_Person,
-                    uncertainPresidentObamaDoc2,
-                    SeedlingOntology.PersonalSocial_Business_Person,
-                    uncertainSecretaryClintonDoc2, getAssertionUri(), system, 0.75);
+            final Resource relation = makeRelation(model, getUri("relation-1"), system);
+            markType(model, getAssertionUri(), relation, SeedlingOntology.PersonalSocial_Business, system, 0.75);
+            markAsArgument(model, relation, SeedlingOntology.PersonalSocial_Business_Person, uncertainPresidentObamaDoc2, system, 0.75);
+            markAsArgument(model, relation, SeedlingOntology.PersonalSocial_Business_Person, uncertainSecretaryClintonDoc2, system, 0.75);
+
             // mark justification "President Obama worked with Secretary Clinton"
             markTextJustification(model, relation, "doc2", 0, 10, system,
                     0.75);
@@ -977,12 +973,10 @@ public class ExamplesAndValidationTest {
 
             // relation that President Obama (of uncertain reference) worked with Secretary Clinton (of uncertain reference)
             // is asserted in document 2
-            final Resource relation = makeRelationInEventForm(model, getUri("relation-1"),
-                    SeedlingOntology.PersonalSocial_Business,
-                    SeedlingOntology.PersonalSocial_Business_Person,
-                    presidentObama,
-                    SeedlingOntology.PersonalSocial_Business_Person,
-                    secretaryClinton, getAssertionUri(), system, 0.75);
+            final Resource relation = makeRelation(model, getUri("relation-1"), system);
+            markType(model, getAssertionUri(), relation, SeedlingOntology.PersonalSocial_Business, system, 0.75);
+            markAsArgument(model, relation, SeedlingOntology.PersonalSocial_Business_Person, presidentObama, system, 0.75);
+            markAsArgument(model, relation, SeedlingOntology.PersonalSocial_Business_Person, secretaryClinton, system, 0.75);
 
             // mark justification "President Obama worked with Secretary Clinton"
             markTextJustification(model, relation, "doc2", 0, 10, system,
@@ -1060,11 +1054,10 @@ public class ExamplesAndValidationTest {
             final Resource louisvilleEntity = makeEntity(model, getEntityUri(), system);
             markType(model, getAssertionUri(), louisvilleEntity, SeedlingOntology.GeopoliticalEntity, system, 1.0);
 
-            makeRelationInEventForm(model, "http://www.test.edu/relations/1",
-                    model.createResource(NAMESPACE + "unknown_type"),
-                    SeedlingOntology.Physical_Resident_Resident, personEntity,
-                    SeedlingOntology.Physical_Resident_Place, louisvilleEntity,
-                    getAssertionUri(), system, 1.0);
+            final Resource relation = makeRelation(model, "http://www.test.edu/relations/1", system);
+            markType(model, getAssertionUri(), relation, model.createResource(NAMESPACE + "unknown_type"), system, 1.0);
+            markAsArgument(model, relation, SeedlingOntology.Physical_Resident_Resident, personEntity, system, 1.0);
+            markAsArgument(model, relation, SeedlingOntology.Physical_Resident_Place, louisvilleEntity, system, 1.0);
 
             testInvalid("Invalid: relation of unknown type");
         }
@@ -1397,7 +1390,7 @@ public class ExamplesAndValidationTest {
                 // setup() already makes type assertions on the entity, event,
                 // and relation objects, justified by a text justification.
 
-                // Note that if you use makeRelationInEventForm, you will need to use the Jena API to obtain
+                // Note that if you use the deprecated makeRelationInEventForm, you will need to use the Jena API to obtain
                 // the type assertion property from the created relation so that you can add a justification.
 
                 testValid("NIST.valid: type assertions must be justified");

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1390,9 +1390,6 @@ public class ExamplesAndValidationTest {
                 // setup() already makes type assertions on the entity, event,
                 // and relation objects, justified by a text justification.
 
-                // Note that if you use the deprecated makeRelationInEventForm, you will need to use the Jena API to obtain
-                // the type assertion property from the created relation so that you can add a justification.
-
                 testValid("NIST.valid: type assertions must be justified");
             }
         }


### PR DESCRIPTION
Work performed:
Reflect the fact that relations can be added to clusters in InterchangeOntology, ontology README, and AIFUtils Javadoc.
Deprecate AIFUtils.makeRelationInEventForm() and update examples not to use it.

I hedged my bets a bit in the README by saying "should be able to" because we don't actually use it / test it.  Should I make it stronger by saying it's "unsupported" or something?  Do we support it?