### PR TITLE
Aida 673

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -25,6 +25,46 @@ aida:SystemShape
         """ ;
     ] .
 
+#########################
+# 4.3 TA3 #4 Each hypothesis graph must have exactly one hypothesis importance value
+#------------------------
+aida:HypothesisGraphImportanceRequiredShape
+    a sh:PropertyShape ;
+    sh:path ( aida:HypothesisShape aida:ImportancePropertyShape ) ;
+    sh:minCount 1 ;
+    sh:maxCount 1 .
+
+#########################
+# 4.3 TA3 #5 Each event or relation (cluster) in the hypothesis must have exactly one event/relation importance value
+#------------------------
+aida:HypothesisEventRelationClusterImportanceRequiredShape
+    a sh:NodeShape ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
+            SELECT ?prototype
+            WHERE {
+                ?prototype a aida:SameAsCluster .
+                ?prototype aida:prototype/a ?type .
+                FILTER( ?type = aida:Event || ?type = aida:Relation )
+            }rest
+        """ ;
+    ];
+
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path aida:importance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+#########################
+# 4.3 TA3 #6 Each edge KE in the hypothesis graph must have exactly one edge importance value
+#------------------------
+
+
 ########################
 # 4.3 TA3 #7 Each entity (cluster) in the hypothesis graph must
 # have exactly one text description (called a "handle")

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -25,37 +25,21 @@ aida:SystemShape
         """ ;
     ] .
 
-#########################
+#########################.;
 # 4.3 TA3 #4 Each hypothesis graph must have exactly one hypothesis importance value
 #------------------------
 aida:HypothesisImportanceRequiredShape
     a sh:PropertyShape ;
-    sh:path aida:importance;
+    sh:path aida:importance ;
+    sh:or (
+        [sh:propertyShape aida:HypothesisShape]
+        [sh:propertyShape aida:EventArgumentShape]
+        [sh:propertyShape aida:RelationArgumentShape]
+    ) ;
     sh:minCount 1 ;
     sh:maxCount 1 .
 
 aida:HypothesisShape
-    sh:property aida:HypothesisImportanceRequiredShape .
-
-#########################
-# 4.3 TA3 #5 Each event or relation (cluster) in the hypothesis must have exactly one event/relation importance value
-#------------------------
-aida:HypothesisEventRelationClusterImportanceRequiredShape
-    a sh:NodeShape ;
-
-    sh:target [
-        a sh:SPARQLTarget ;
-        sh:select """
-            PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
-            SELECT ?prototype
-            WHERE {
-                ?prototype a aida:SameAsCluster .
-                ?prototype aida:prototype/a ?type .
-                FILTER( ?type = aida:Event || ?type = aida:Relation )
-            }
-        """ ;
-    ];
-
     sh:property aida:HypothesisImportanceRequiredShape .
 
 #########################

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -28,11 +28,14 @@ aida:SystemShape
 #########################
 # 4.3 TA3 #4 Each hypothesis graph must have exactly one hypothesis importance value
 #------------------------
-aida:HypothesisGraphImportanceRequiredShape
+aida:HypothesisImportanceRequiredShape
     a sh:PropertyShape ;
-    sh:path ( aida:HypothesisShape aida:ImportancePropertyShape ) ;
+    sh:path aida:importance;
     sh:minCount 1 ;
     sh:maxCount 1 .
+
+aida:HypothesisShape
+    sh:property aida:HypothesisImportanceRequiredShape .
 
 #########################
 # 4.3 TA3 #5 Each event or relation (cluster) in the hypothesis must have exactly one event/relation importance value
@@ -49,31 +52,20 @@ aida:HypothesisEventRelationClusterImportanceRequiredShape
                 ?prototype a aida:SameAsCluster .
                 ?prototype aida:prototype/a ?type .
                 FILTER( ?type = aida:Event || ?type = aida:Relation )
-            }rest
+            }
         """ ;
     ];
 
-    sh:property [
-        a sh:PropertyShape ;
-        sh:path aida:importance ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-    ] .
+    sh:property aida:HypothesisImportanceRequiredShape .
 
 #########################
 # 4.3 TA3 #6 Each edge KE in the hypothesis graph must have exactly one edge importance value
 #------------------------
-aida:HypothesisEdgeRequireImportanceShape
-    a sh:PropertyShape ;
-    sh:path ( aida:importance) ;
-    sh:minCount 1;
-    sh:maxCount 1 .
-
 aida:EventArgumentShape
-    sh:property HypothesisEdgeRequireImportanceShape .
+    sh:property aida:HypothesisImportanceRequiredShape .
 
 aida:RelationArgumentShape
-    sh:property HypothesisEdgeRequireImportanceShape .
+    sh:property aida:HypothesisImportanceRequiredShape .
 
 ########################
 # 4.3 TA3 #7 Each entity (cluster) in the hypothesis graph must

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -28,19 +28,14 @@ aida:SystemShape
 #########################.;
 # 4.3 TA3 #4 Each hypothesis graph must have exactly one hypothesis importance value
 #------------------------
-aida:HypothesisImportanceRequiredShape
+aida:ImportanceRequiredShape
     a sh:PropertyShape ;
     sh:path aida:importance ;
-    sh:or (
-        [sh:propertyShape aida:HypothesisShape]
-        [sh:propertyShape aida:EventArgumentShape]
-        [sh:propertyShape aida:RelationArgumentShape]
-    ) ;
     sh:minCount 1 ;
     sh:maxCount 1 .
 
 aida:HypothesisShape
-    sh:property aida:HypothesisImportanceRequiredShape .
+    sh:property aida:ImportanceRequiredShape .
 
 #########################
 # 4.3 TA3 #5 Each event or relation (cluster) in the hypothesis must have exactly one event/relation importance value
@@ -62,21 +57,16 @@ aida:HypothesisEventRelationClusterImportanceRequiredShape
     ];
 
     # sh:maxCount 1 is inherited from aida_ontology.shacl
-    sh:property [
-        a sh:PropertyShape ;
-        sh:path aida:importance ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-    ] .
+    sh:property aida:ImportanceRequiredShape .
 
 #########################
 # 4.3 TA3 #6 Each edge KE in the hypothesis graph must have exactly one edge importance value
 #------------------------
 aida:EventArgumentShape
-    sh:property aida:HypothesisImportanceRequiredShape .
+    sh:property aida:ImportanceRequiredShape .
 
 aida:RelationArgumentShape
-    sh:property aida:HypothesisImportanceRequiredShape .
+    sh:property aida:ImportanceRequiredShape .
 
 ########################
 # 4.3 TA3 #7 Each entity (cluster) in the hypothesis graph must

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -43,6 +43,33 @@ aida:HypothesisShape
     sh:property aida:HypothesisImportanceRequiredShape .
 
 #########################
+# 4.3 TA3 #5 Each event or relation (cluster) in the hypothesis must have exactly one event/relation importance value
+#------------------------
+aida:HypothesisEventRelationClusterImportanceRequiredShape
+    a sh:NodeShape ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
+            SELECT ?prototype
+            WHERE {
+                ?prototype a aida:SameAsCluster .
+                ?prototype aida:prototype/a ?type .
+                FILTER( ?type = aida:Event || ?type = aida:Relation )
+            }
+        """ ;
+    ];
+
+    # sh:maxCount 1 is inherited from aida_ontology.shacl
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path aida:importance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+#########################
 # 4.3 TA3 #6 Each edge KE in the hypothesis graph must have exactly one edge importance value
 #------------------------
 aida:EventArgumentShape

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -63,7 +63,17 @@ aida:HypothesisEventRelationClusterImportanceRequiredShape
 #########################
 # 4.3 TA3 #6 Each edge KE in the hypothesis graph must have exactly one edge importance value
 #------------------------
+aida:HypothesisEdgeRequireImportanceShape
+    a sh:PropertyShape ;
+    sh:path ( aida:importance) ;
+    sh:minCount 1;
+    sh:maxCount 1 .
 
+aida:EventArgumentShape
+    sh:property HypothesisEdgeRequireImportanceShape .
+
+aida:RelationArgumentShape
+    sh:property HypothesisEdgeRequireImportanceShape .
 
 ########################
 # 4.3 TA3 #7 Each entity (cluster) in the hypothesis graph must

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1488,7 +1488,7 @@ public class ExamplesAndValidationTest {
             @Test
             // No handle property on entity cluster in hypothesis
             void invalidNoHandle() {
-                Resource newEntity = makeEntity(model, getEntityUri(), system);
+                final Resource newEntity = makeEntity(model, getEntityUri(), system);
                 makeClusterWithPrototype(model, getClusterUri(), newEntity, system);
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
@@ -1502,8 +1502,8 @@ public class ExamplesAndValidationTest {
             // Two handle properties on entity cluster in hypothesis
             void invalidMultipleHandles() {
 
-                Resource newEntity = makeEntity(model, getEntityUri(), system);
-                Resource cluster = makeClusterWithPrototype(model, getClusterUri(), newEntity, "handle2", system);
+                final Resource newEntity = makeEntity(model, getEntityUri(), system);
+                final Resource cluster = makeClusterWithPrototype(model, getClusterUri(), newEntity, "handle2", system);
                 cluster.addProperty(AidaAnnotationOntology.HANDLE, "handle3");
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
@@ -1541,6 +1541,58 @@ public class ExamplesAndValidationTest {
             }
         }
 
+        // Each event or relation (cluster) in the hypothesis must have exactly one importance value
+        @Nested
+        class HypothesisEntityRelationClusterImportanceValue {
+
+            private final String documentEventUri = getUri("V779961.00010");
+            private final String putinResidesDocumentRelationUri = getUri("R779959.00000");
+            Resource event;
+            Resource relation;
+
+            @BeforeEach
+            void setup() {
+                event = makeEvent(model, documentEventUri, system);
+                markJustification(markType(model, getAssertionUri(), event,
+                        SeedlingOntology.Personnel_Elect, system, 1.0), justification);
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
+
+                relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+                markJustification(markType(model, getAssertionUri(), relation,
+                        SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
+
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(event), system), 100);
+
+            }
+
+            @Test
+            void invalidEvent() {
+                //invalid event cluster no importance
+                makeClusterWithPrototype(model, getClusterUri(), event, system);
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), relation, system), 99);
+                testInvalid("NISTHypothesis.invalid: Each event or relation (cluster) in the hypothesis must " +
+                        "have exactly one importance value");
+            }
+
+            @Test
+            void invalidRelation() {
+                //invalid relation cluster no importance
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
+                makeClusterWithPrototype(model, getClusterUri(), relation, system);
+                testInvalid("NISTHypothesis.invalid: Each event or relation (cluster) in the hypothesis must " +
+                        "have exactly one importance value");
+            }
+
+            @Test
+            void valid() {
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), relation, system), 99);
+                testValid("NISTHypothesis.valid: Each event or relation (cluster) in the hypothesis must " +
+                        "have exactly one importance value");
+            }
+        }
+
         // Each edge KE in the hypothesis graph must have exactly one edge importance value
         @Nested
         class HypothesisEdgeImportanceValue {
@@ -1563,48 +1615,54 @@ public class ExamplesAndValidationTest {
 
                 markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
                 markImportance(makeClusterWithPrototype(model, getClusterUri(), relation, system), 88);
-
-                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
-                        Collections.singleton(relation), system), 100);
             }
 
             @Test
-            void invalidEvent() {
+            void invalidEventEdge() {
 
                 markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
                         entity, system, 0.785);
 
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(event), system), 100);
+
                 testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");
             }
 
             @Test
-            void invalidRelation() {
+            void invalidRelationEdge() {
 
                 markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
                         entity, system, 0.785);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(relation), system), 100);
 
                 testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");
             }
 
             @Test
-            void validEvent() {
+            void validEventEdge() {
 
                 // link entity to the event
                 markImportance(markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
                         entity, system, 0.785), 110);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(event), system), 100);
 
                 testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");
             }
 
             @Test
-            void validRelation() {
+            void validRelationEdge() {
 
                 // link entity to the relation
                 markImportance(markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
                         entity, system, 0.785), 120);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(relation), system), 100);
 
                 testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1563,7 +1563,7 @@ public class ExamplesAndValidationTest {
                         SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
 
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
-                        Collections.singleton(event), system), 100);
+                        ImmutableSet.of(event, relation), system), 100);
 
             }
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1452,6 +1452,7 @@ public class ExamplesAndValidationTest {
                     42, 143, system, 0.973);
             entity = makeEntity(model, getEntityUri(), system);
             entityCluster = makeClusterWithPrototype(model, getClusterUri(), entity, "handle", system);
+
             markJustification(addType(entity, SeedlingOntology.Person), justification);
         }
 
@@ -1528,14 +1529,102 @@ public class ExamplesAndValidationTest {
             @Test
             void invalid() {
                 makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(entity), system);
-                testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have exactly one hypothesis importance value");
+                testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have exactly one" +
+                        " hypothesis importance value");
             }
             @Test
             void valid() {
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
                         Collections.singleton(entity), system), 100);
-                testValid("NISTHypothesis.valid: Each entity cluster in the hypothesis graph must have " +
-                        "exactly one handle");
+                testValid("NISTHypothesis.valid: Each hypothesis graph must have exactly one" +
+                        " hypothesis importance value");
+            }
+        }
+
+        // Each edge KE in the hypothesis graph must have exactly one edge importance value
+        @Nested
+        class HypothesisEdgeImportanceValue {
+
+            private final String documentEventUri = getUri("V779961.00010");
+            private final String putinResidesDocumentRelationUri = getUri("R779959.00000");
+
+            @Test
+            void invalidEvent() {
+                final Resource event = makeEvent(model, documentEventUri, system);
+                markJustification(markType(model, getAssertionUri(), event,
+                        SeedlingOntology.Personnel_Elect, system, 1.0), justification);
+
+                makeClusterWithPrototype(model, getClusterUri(), event, system);
+
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(event), system), 100);
+
+                markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
+                        entity, system, 0.785);
+
+                testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
+                        "edge importance value");
+            }
+
+            @Test
+            void invalidRelation() {
+
+                final Resource relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+                markJustification(markType(model, getAssertionUri(), relation,
+                        SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
+
+                makeClusterWithPrototype(model, getClusterUri(), relation, system);
+
+                // link entity to the relation
+                markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
+                        entity, system, 0.785);
+
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(relation), system), 100);
+
+                testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
+                        "edge importance value");
+            }
+
+            @Test
+            void validEvent() {
+
+
+                final Resource event = makeEvent(model, documentEventUri, system);
+                markJustification(markType(model, getAssertionUri(), event,
+                        SeedlingOntology.Personnel_Elect, system, 1.0), justification);
+
+                makeClusterWithPrototype(model, getClusterUri(), event, system);
+
+                // link entity to the event
+                markImportance(markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
+                        entity, system, 0.785), 110);
+
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                       Collections.singleton(event), system), 100);
+
+                testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
+                        "edge importance value");
+            }
+
+            @Test
+            void validRelation() {
+
+                final Resource relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+                markJustification(markType(model, getAssertionUri(), relation,
+                        SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
+
+                makeClusterWithPrototype(model, getClusterUri(), relation, system);
+
+                // link entity to the relation
+                markImportance(markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
+                        entity, system, 0.785), 120);
+
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(relation), system), 100);
+
+                testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
+                        "edge importance value");
             }
         }
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1460,8 +1460,11 @@ public class ExamplesAndValidationTest {
         class SingleHypothesis {
             @Test
             void invalidTooMany() {
-                makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(entity), system);
-                makeHypothesis(model, getUri("hypothesis-2"), Collections.singleton(entity), system);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(entity), system), 100);
+
+                markImportance(makeHypothesis(model, getUri("hypothesis-2"),
+                        Collections.singleton(entity), system), 101);
                 testInvalid("NISTHypothesis.invalid (too many): there should be exactly 1 hypothesis");
             }
 
@@ -1472,11 +1475,13 @@ public class ExamplesAndValidationTest {
 
             @Test
             void valid() {
-                makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(entity), system);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(entity), system), 100);
                 testValid("NISTHypothesis.valid: there should be exactly 1 hypothesis");
             }
         }
 
+        // Each entity (cluster) in the hypothesis graph must have exactly one handle
         @Nested
         class EntityClusterRequiredHandle {
             @Test
@@ -1485,7 +1490,8 @@ public class ExamplesAndValidationTest {
                 Resource newEntity = makeEntity(model, getEntityUri(), system);
                 makeClusterWithPrototype(model, getClusterUri(), newEntity, system);
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
-                makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(newEntity), system);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(newEntity), system), 100);
 
                 testInvalid("NISTHypothesis.invalid: Each entity cluster in the hypothesis graph must have " +
                         "exactly one handle");
@@ -1499,7 +1505,8 @@ public class ExamplesAndValidationTest {
                 Resource cluster = makeClusterWithPrototype(model, getClusterUri(), newEntity, "handle2", system);
                 cluster.addProperty(AidaAnnotationOntology.HANDLE, "handle3");
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
-                makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(newEntity), system);
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(newEntity), system), 100);
 
                 testInvalid("NISTHypothesis.invalid: Each entity cluster in the hypothesis graph must have " +
                             "exactly one handle");
@@ -1508,8 +1515,26 @@ public class ExamplesAndValidationTest {
             @Test
             // One handle on entity cluster in hypothesis
             void valid() {
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(entity), system), 100);
+                testValid("NISTHypothesis.valid: Each entity cluster in the hypothesis graph must have " +
+                        "exactly one handle");
+            }
+        }
+
+        // Each hypothesis graph must have exactly one hypothesis importance value
+        @Nested
+        class HypothesisImportanceValue {
+            @Test
+            void invalid() {
                 makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(entity), system);
-                testValid("NISTHypothesis.invalid: Each entity cluster in the hypothesis graph must have " +
+                testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have exactly one hypothesis importance value");
+            }
+            @Test
+            void valid() {
+                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
+                        Collections.singleton(entity), system), 100);
+                testValid("NISTHypothesis.valid: Each entity cluster in the hypothesis graph must have " +
                         "exactly one handle");
             }
         }

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1544,7 +1544,7 @@ public class ExamplesAndValidationTest {
 
         // Each event or relation (cluster) in the hypothesis must have exactly one importance value
         @Nested
-        class HypothesisEntityRelationClusterImportanceValue {
+        class HypothesisEventRelationClusterImportanceValue {
 
             private final String documentEventUri = getUri("event-1");
             private final String relationUri = getUri("relation-1");

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1623,7 +1623,7 @@ public class ExamplesAndValidationTest {
 
                 //invalid event argument, needs importance value
                 markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
-                        entity, system, 0.785);
+                        entity, system, 0.785, "event-argument-1");
 
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
                         Collections.singleton(event), system), 100);
@@ -1637,7 +1637,7 @@ public class ExamplesAndValidationTest {
 
                 //invalid erelation argument, needs importance value
                 markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
-                        entity, system, 0.785);
+                        entity, system, 0.785, "relation-argument-1");
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
                         Collections.singleton(relation), system), 100);
 
@@ -1650,7 +1650,7 @@ public class ExamplesAndValidationTest {
 
                 // link entity to the event
                 markImportance(markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
-                        entity, system, 0.785), 110);
+                        entity, system, 0.785, "event-argument-1"), 110);
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
                         Collections.singleton(event), system), 100);
 
@@ -1663,7 +1663,7 @@ public class ExamplesAndValidationTest {
 
                 // link entity to the relation
                 markImportance(markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
-                        entity, system, 0.785), 120);
+                        entity, system, 0.785, "relation-argument-1"), 120);
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
                         Collections.singleton(relation), system), 100);
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1463,7 +1463,6 @@ public class ExamplesAndValidationTest {
             void invalidTooMany() {
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
                         Collections.singleton(entity), system), 100);
-
                 markImportance(makeHypothesis(model, getUri("hypothesis-2"),
                         Collections.singleton(entity), system), 101);
                 testInvalid("NISTHypothesis.invalid (too many): there should be exactly 1 hypothesis");
@@ -1503,7 +1502,8 @@ public class ExamplesAndValidationTest {
             void invalidMultipleHandles() {
 
                 final Resource newEntity = makeEntity(model, getEntityUri(), system);
-                final Resource cluster = makeClusterWithPrototype(model, getClusterUri(), newEntity, "handle2", system);
+                final Resource cluster = makeClusterWithPrototype(model, getClusterUri(), newEntity,
+                        "handle2", system);
                 cluster.addProperty(AidaAnnotationOntology.HANDLE, "handle3");
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
@@ -1528,6 +1528,7 @@ public class ExamplesAndValidationTest {
         class HypothesisImportanceValue {
             @Test
             void invalid() {
+                //invalid hypothesis, no importance value
                 makeHypothesis(model, getUri("hypothesis-1"), Collections.singleton(entity), system);
                 testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have exactly one" +
                         " hypothesis importance value");
@@ -1545,8 +1546,8 @@ public class ExamplesAndValidationTest {
         @Nested
         class HypothesisEntityRelationClusterImportanceValue {
 
-            private final String documentEventUri = getUri("V779961.00010");
-            private final String putinResidesDocumentRelationUri = getUri("R779959.00000");
+            private final String documentEventUri = getUri("ldc:event-1");
+            private final String relationUri = getUri("ldc:relation-1");
             Resource event;
             Resource relation;
 
@@ -1557,7 +1558,7 @@ public class ExamplesAndValidationTest {
                         SeedlingOntology.Personnel_Elect, system, 1.0), justification);
                 markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
 
-                relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+                relation = makeRelation(model, relationUri, system);
                 markJustification(markType(model, getAssertionUri(), relation,
                         SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
 
@@ -1568,7 +1569,7 @@ public class ExamplesAndValidationTest {
 
             @Test
             void invalidEvent() {
-                //invalid event cluster no importance
+                //invalid event cluster, no importance value
                 makeClusterWithPrototype(model, getClusterUri(), event, system);
                 markImportance(makeClusterWithPrototype(model, getClusterUri(), relation, system), 99);
                 testInvalid("NISTHypothesis.invalid: Each event or relation (cluster) in the hypothesis must " +
@@ -1577,7 +1578,7 @@ public class ExamplesAndValidationTest {
 
             @Test
             void invalidRelation() {
-                //invalid relation cluster no importance
+                //invalid relation cluster, no importance value
                 markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
                 makeClusterWithPrototype(model, getClusterUri(), relation, system);
                 testInvalid("NISTHypothesis.invalid: Each event or relation (cluster) in the hypothesis must " +
@@ -1597,8 +1598,8 @@ public class ExamplesAndValidationTest {
         @Nested
         class HypothesisEdgeImportanceValue {
 
-            private final String documentEventUri = getUri("V779961.00010");
-            private final String putinResidesDocumentRelationUri = getUri("R779959.00000");
+            private final String documentEventUri = getUri("ldc:event-1");
+            private final String relationUri = getUri("ldc:relation-1");
             Resource event;
             Resource relation;
 
@@ -1609,7 +1610,7 @@ public class ExamplesAndValidationTest {
                 markJustification(markType(model, getAssertionUri(), event,
                         SeedlingOntology.Personnel_Elect, system, 1.0), justification);
 
-                relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+                relation = makeRelation(model, relationUri, system);
                 markJustification(markType(model, getAssertionUri(), relation,
                         SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
 
@@ -1620,6 +1621,7 @@ public class ExamplesAndValidationTest {
             @Test
             void invalidEventEdge() {
 
+                //invalid event argument, needs importance value
                 markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
                         entity, system, 0.785);
 
@@ -1633,6 +1635,7 @@ public class ExamplesAndValidationTest {
             @Test
             void invalidRelationEdge() {
 
+                //invalid erelation argument, needs importance value
                 markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
                         entity, system, 0.785);
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1547,17 +1547,29 @@ public class ExamplesAndValidationTest {
 
             private final String documentEventUri = getUri("V779961.00010");
             private final String putinResidesDocumentRelationUri = getUri("R779959.00000");
+            Resource event;
+            Resource relation;
 
-            @Test
-            void invalidEvent() {
-                final Resource event = makeEvent(model, documentEventUri, system);
+            @BeforeEach
+            void setup() {
+
+                event = makeEvent(model, documentEventUri, system);
                 markJustification(markType(model, getAssertionUri(), event,
                         SeedlingOntology.Personnel_Elect, system, 1.0), justification);
 
-                makeClusterWithPrototype(model, getClusterUri(), event, system);
+                relation = makeRelation(model, putinResidesDocumentRelationUri, system);
+                markJustification(markType(model, getAssertionUri(), relation,
+                        SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
+
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), event, system), 88);
+                markImportance(makeClusterWithPrototype(model, getClusterUri(), relation, system), 88);
 
                 markImportance(makeHypothesis(model, getUri("hypothesis-1"),
-                        Collections.singleton(event), system), 100);
+                        Collections.singleton(relation), system), 100);
+            }
+
+            @Test
+            void invalidEvent() {
 
                 markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
                         entity, system, 0.785);
@@ -1569,18 +1581,8 @@ public class ExamplesAndValidationTest {
             @Test
             void invalidRelation() {
 
-                final Resource relation = makeRelation(model, putinResidesDocumentRelationUri, system);
-                markJustification(markType(model, getAssertionUri(), relation,
-                        SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
-
-                makeClusterWithPrototype(model, getClusterUri(), relation, system);
-
-                // link entity to the relation
                 markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
                         entity, system, 0.785);
-
-                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
-                        Collections.singleton(relation), system), 100);
 
                 testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");
@@ -1589,19 +1591,9 @@ public class ExamplesAndValidationTest {
             @Test
             void validEvent() {
 
-
-                final Resource event = makeEvent(model, documentEventUri, system);
-                markJustification(markType(model, getAssertionUri(), event,
-                        SeedlingOntology.Personnel_Elect, system, 1.0), justification);
-
-                makeClusterWithPrototype(model, getClusterUri(), event, system);
-
                 // link entity to the event
                 markImportance(markAsArgument(model, event, SeedlingOntology.Personnel_Elect_Elect,
                         entity, system, 0.785), 110);
-
-                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
-                       Collections.singleton(event), system), 100);
 
                 testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");
@@ -1610,18 +1602,9 @@ public class ExamplesAndValidationTest {
             @Test
             void validRelation() {
 
-                final Resource relation = makeRelation(model, putinResidesDocumentRelationUri, system);
-                markJustification(markType(model, getAssertionUri(), relation,
-                        SeedlingOntology.GeneralAffiliation_APORA, system, 1.0), justification);
-
-                makeClusterWithPrototype(model, getClusterUri(), relation, system);
-
                 // link entity to the relation
                 markImportance(markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliation,
                         entity, system, 0.785), 120);
-
-                markImportance(makeHypothesis(model, getUri("hypothesis-1"),
-                        Collections.singleton(relation), system), 100);
 
                 testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
                         "edge importance value");

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1546,8 +1546,8 @@ public class ExamplesAndValidationTest {
         @Nested
         class HypothesisEntityRelationClusterImportanceValue {
 
-            private final String documentEventUri = getUri("ldc:event-1");
-            private final String relationUri = getUri("ldc:relation-1");
+            private final String documentEventUri = getUri("event-1");
+            private final String relationUri = getUri("relation-1");
             Resource event;
             Resource relation;
 
@@ -1598,8 +1598,8 @@ public class ExamplesAndValidationTest {
         @Nested
         class HypothesisEdgeImportanceValue {
 
-            private final String documentEventUri = getUri("ldc:event-1");
-            private final String relationUri = getUri("ldc:relation-1");
+            private final String documentEventUri = getUri("event-1");
+            private final String relationUri = getUri("relation-1");
             Resource event;
             Resource relation;
 


### PR DESCRIPTION
- Created hypothesis restriction to enforce edge KE's in the hypothesis graph must have exactly one edge importance value
- Created hypothesis restriction to enforce event and relation clusters in the hypothesis must have exactly one importance value
- Created hypothesis restriction to enforce that the hypothesis must have exactly one importance value
- Created valid and invalid test cases to validate all new aforementioned hypothesis restrictions 
- Updated all other hypothesis test cases that were impacted by the required importance value