### PR TITLE
AIDA-612:  Migrate validator from Seedling to LDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:  <br>
 Either a file (-f) or a directory (-d) must be specified (but not both).  <br>
 Exactly one of --ldc, --program, or --ont must be specified.  <br>
 Ontology files can be found in `src/main/resources/com/ncc/aif/ontologies`:
-- LDC (LO): `SeedlingOntology`
+- LDC (LO): `LDCOntology`
 - Program (AO): `EntityOntology`, `EventOntology`, `RelationOntology`
 
 ### Validator return values

--- a/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/src/main/java/com/ncc/aif/AIFUtils.java
@@ -975,7 +975,7 @@ public class AIFUtils {
      * <li>the number of documents that justify the KE;</li>
      * <li>time stamps of justification documents; or</li>
      * <li>fringe type(s) for each image or shot, to describe features that are not represented explicitly in the
-     * seedling ontology.  For example: Physical.LocatedNear.Inside(Arg1_Type=Person.Soldier, Arg2_Type=Facility.Hospital)</li>
+     * ontology.  For example: Physical.LocatedNear.Inside(Arg1_Type=Person.Soldier, Arg2_Type=Facility.Hospital)</li>
      * </ul>
      * <p>
      * The KE is not allowed to contain any strings from document text except for the strings in the HasName,
@@ -1007,7 +1007,7 @@ public class AIFUtils {
      * <li>the number of documents that justify the KE;</li>
      * <li>time stamps of justification documents; or</li>
      * <li>fringe type(s) for each image or shot, to describe features that are not represented explicitly in the
-     * seedling ontology.  For example: Physical.LocatedNear.Inside(Arg1_Type=Person.Soldier, Arg2_Type=Facility.Hospital)</li>
+     * ontology.  For example: Physical.LocatedNear.Inside(Arg1_Type=Person.Soldier, Arg2_Type=Facility.Hospital)</li>
      * </ul>
      * <p>
      * The KE is not allowed to contain any strings from document text except for the strings in the HasName,

--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -36,7 +36,7 @@ public final class ValidateAIF {
     private static final String NIST_HYPOTHESIS_SHACL_RESNAME = "com/ncc/aif/restricted_hypothesis_aif.shacl";
     private static final String INTERCHANGE_RESNAME = "com/ncc/aif/ontologies/InterchangeOntology";
     private static final String AIDA_DOMAIN_COMMON_RESNAME = "com/ncc/aif/ontologies/AidaDomainOntologiesCommon";
-    private static final String LDC_RESNAME = "com/ncc/aif/ontologies/SeedlingOntology";
+    private static final String LDC_RESNAME = "com/ncc/aif/ontologies/LDCOntology";
     private static final String AO_ENTITIES_RESNAME = "com/ncc/aif/ontologies/EntityOntology";
     private static final String AO_EVENTS_RESNAME = "com/ncc/aif/ontologies/EventOntology";
     private static final String AO_RELATIONS_RESNAME = "com/ncc/aif/ontologies/RelationOntology";
@@ -168,7 +168,7 @@ public final class ValidateAIF {
                 "Either a file (-f) or a directory (-d) must be specified (but not both).\n" +
                 "Exactly one of --ldc, --program, or --ont must be specified.\n" +
                 "Ontology files can be found in src/main/resources/com/ncc/aif/ontologies:\n" +
-                "- LDC: SeedlingOntology\n" +
+                "- LDC: LDCOntology\n" +
                 "- Program: EntityOntology, EventOntology, RelationOntology\n" +
                 "\n" +
                 "For more information, see the AIF README.");

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -28,8 +28,8 @@
 # There are two RDF ontologies to be concerned with. What is described and validated here is the
 # "interchange ontology".  The domain working group is also specifying a "domain ontology" (e.g.
 # entity types, event types, etc.).  The AIDA program domain ontology has not yet been specified.
-# We currently have two available domain ontologies, but for ColdStart and LDC Seedling, both of
-# which have OWL files in the src/main/resources/edu/gaia directory of this repository.
+# We currently have two available domain ontologies, but for LDC and LDC Seedling, both of
+# which have OWL files in the src/main/resources/com/ncc/aif/ontologies directory of this repository.
 # We assume all domain ontologies
 # derive their entity, event, and relation types from aidaDomainCommon:EntityType, etc.
 #


### PR DESCRIPTION
Updated that --ldc now uses LDCOntology, not SeedlingOntology.
Updated some references to Seedling / LDC.