### PR TITLE
AIDA-703:  Check file size for TA3 output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Ontology files can be found in `src/main/resources/com/ncc/aif/ontologies`:
 ### Validator return values
 Return values from the command-line validator are as follows:
 * `0 (Success)`.  There were no validation (or any other) errors.
-* `1 (Validation Error)`.	All specified files were validated but at least one failed validation.
+* `1 (Validation Error)`.	All specified files were validated but at least one failed validation.  Supersedes a File Error.
 * `2 (Usage Error)`.  There was a problem interpreting command-line arguments.  No validation was performed.
 * `3 (File Error)`.  A file was rejected, either due to an I/O error or because it didn't meet certain criteria.
   Logging indicates the nature of the problem(s).  Validation may have been performed on a subset of specified KBs.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Return values from the command-line validator are as follows:
 * `0 (Success)`.  There were no validation (or any other) errors.
 * `1 (Validation Error)`.	All specified files were validated but at least one failed validation.
 * `2 (Usage Error)`.  There was a problem interpreting command-line arguments.  No validation was performed.
-* `3 (File Error)`.  There was a problem reading one or more files or directories.  Validation may have been performed on a subset of specified KBs.  If there is an error loading any ontologies or SHACL files, then no validation is performed.
+* `3 (File Error)`.  A file was rejected, either due to an I/O error or because it didn't meet certain criteria.
+  Logging indicates the nature of the problem(s).  Validation may have been performed on a subset of specified KBs.
+  If there is an error loading any ontologies or SHACL files, then no validation is performed.
 
 ### Running the validator in code
 To run the validator programmatically in Java code, first use one of the public `ValidateAIF.createXXX()`

--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -394,7 +394,7 @@ public final class ValidateAIF {
             logger.info("-> Validating " + fileToValidate + " at " + format.format(date) +
                     " (" + ++fileNum + " of " + filesToValidate.size() + ").");
             final OntModel dataToBeValidated = ModelFactory.createOntologyModel();
-            boolean notSkipped = ((restriction == Restriction.NIST_HYPOTHESIS) && checkHypothesisSize(fileToValidate))
+            boolean notSkipped = ((restriction != Restriction.NIST_HYPOTHESIS) || checkHypothesisSize(fileToValidate))
                     && loadFile(dataToBeValidated, fileToValidate);
             if (notSkipped) {
                 if (!validator.validateKB(dataToBeValidated)) {


### PR DESCRIPTION
Check file size for TA3 output, also refactored main method a bit.  I'm open to more refactoring, breaking up blocks of code into private methods.  Let me know.

To test, create a file about 5MB (it doesn't have to be a valid ttl) and invoke the validator (via  command line or IntelliJ) with command-line options of `--ldc -f <filename>.ttl --nist-ta3`
Tweak the file to be slightly more or less than 5MB and make sure the validator rejects the file that is > 5M.

Also, test some other combinations of valid and invalid kbs.  Note that --ldc now uses the LDC ontology, not Seedling.  But you can use an essentially empty file as a valid KB.