### PR TITLE
Aida 674

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -148,8 +148,7 @@ aida:HypothesisClusterMembersSameAsBaseClass
 aida:HypothesisClusterMembersShape
     a sh:NodeShape ;
     sh:targetClass aida:ClusterMembership ;
-    sh:sparql aida:HypothesisClusterMembersSameAsBaseClass
-    .
+    sh:sparql aida:HypothesisClusterMembersSameAsBaseClass .
 
 ########################
 # 4.3 TA3 #1.a All KEs in model should be referenced by hypothesis

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -128,19 +128,20 @@ aida:HypothesisEntityClusterRequireHandle
 #------------------------
 aida:HypothesisClusterMembersSameAsBaseClass
     a sh:SPARQLConstraint ;
-    sh:message "All Clusters must be homogeneous by base class (Entity, Event, or Relation). Found {?value}" ;
+    sh:message "All Clusters must be homogeneous by base class (Entity, Event, or Relation). Found {?prototype} in cluster {?cluster}" ;
     sh:select """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
-        SELECT $this (COUNT(?cluster) AS ?value)
+        SELECT $this ?cluster ?prototype  (COUNT(?cluster) AS ?value)
         WHERE {
       	    $this aida:cluster ?cluster .
             $this aida:clusterMember/rdf:type ?memberType .
             ?cluster a aida:SameAsCluster .
-            ?cluster aida:prototype/rdf:type ?prototypeType .
+            ?cluster aida:prototype ?prototype .
+            ?prototype rdf:type ?prototypeType .
             FILTER ( ?memberType != ?prototypeType )
         }
-        GROUP BY $this
+        GROUP BY $this ?cluster ?prototype
         HAVING (COUNT(?cluster) != 0)
     """
     .

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -128,17 +128,16 @@ aida:HypothesisEntityClusterRequireHandle
 #------------------------
 aida:HypothesisClusterMembersSameAsBaseClass
     a sh:SPARQLConstraint ;
-    sh:message "All Clusters must be homogeneous by base class (Entity, Event, or Relation). Found {?prototype} in cluster {?cluster}" ;
+    sh:message "All Clusters must have homogeneous members by base class (Entity, Event, or Relation)" ;
     sh:select """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
-        SELECT $this ?cluster ?prototype
+        SELECT $this (?member AS $value)
         WHERE {
-      	    $this aida:cluster ?cluster .
-            $this aida:clusterMember/rdf:type ?memberType .
-            ?cluster a aida:SameAsCluster .
-            ?cluster aida:prototype ?prototype .
-            ?prototype rdf:type ?prototypeType .
+      	    ?membership aida:cluster $this .
+            ?membership aida:clusterMember ?member .
+            ?member rdf:type ?memberType .
+            $this aida:prototype/rdf:type ?prototypeType .
             FILTER ( ?memberType != ?prototypeType )
         }
     """
@@ -146,7 +145,7 @@ aida:HypothesisClusterMembersSameAsBaseClass
 
 aida:HypothesisClusterMembersShape
     a sh:NodeShape ;
-    sh:targetClass aida:ClusterMembership ;
+    sh:targetClass aida:SameAsCluster;
     sh:sparql aida:HypothesisClusterMembersSameAsBaseClass .
 
 ########################

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -132,7 +132,7 @@ aida:HypothesisClusterMembersSameAsBaseClass
     sh:select """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
-        SELECT $this ?cluster ?prototype  (COUNT(?cluster) AS ?value)
+        SELECT $this ?cluster ?prototype
         WHERE {
       	    $this aida:cluster ?cluster .
             $this aida:clusterMember/rdf:type ?memberType .
@@ -141,8 +141,6 @@ aida:HypothesisClusterMembersSameAsBaseClass
             ?prototype rdf:type ?prototypeType .
             FILTER ( ?memberType != ?prototypeType )
         }
-        GROUP BY $this ?cluster ?prototype
-        HAVING (COUNT(?cluster) != 0)
     """
     .
 

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -124,6 +124,35 @@ aida:HypothesisEntityClusterRequireHandle
     ] .
 
 ########################
+# 4.3 TA3 #7  Clusters must be homogeneous by base class (Entity, Event, or Relation)
+#------------------------
+aida:HypothesisClusterMembersSameAsBaseClass
+    a sh:SPARQLConstraint ;
+    sh:message "All Clusters must be homogeneous by base class (Entity, Event, or Relation). Found {?value}" ;
+    sh:select """
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
+
+        SELECT $this (COUNT(?cluster) AS ?value)
+        WHERE {
+      	    $this aida:cluster ?cluster .
+            $this aida:clusterMember/rdf:type ?memberType .
+            ?cluster a aida:SameAsCluster .
+            ?cluster aida:prototype/rdf:type ?prototypeType .
+            FILTER ( ?memberType != ?prototypeType )
+        }
+        GROUP BY $this
+        HAVING (COUNT(?cluster) != 0)
+    """
+    .
+
+aida:HypothesisClusterMembersShape
+    a sh:NodeShape ;
+    sh:targetClass aida:ClusterMembership ;
+    sh:sparql aida:HypothesisClusterMembersSameAsBaseClass
+    .
+
+########################
 # 4.3 TA3 #1.a All KEs in model should be referenced by hypothesis
 #------------------------
 aida:KEsMustBeReferenced

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -132,7 +132,6 @@ aida:HypothesisClusterMembersSameAsBaseClass
     sh:select """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
-
         SELECT $this (COUNT(?cluster) AS ?value)
         WHERE {
       	    $this aida:cluster ?cluster .

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1786,7 +1786,8 @@ public class ExamplesAndValidationTest {
                         "or relation with at least one edge.");
             }
 
-            @Test
+            // TODO This test case needs to be updated and @Test needs to be added back in  once we decide on the
+            // TODO new design of this class upon the completion of AIDA-698.
             void validRelationAndRelationEdge() {
                 final Resource relation = makeRelation(model, getUri("relation-1"), system);
                 markImportance(makeClusterWithPrototype(model, getClusterUri(), relation, "Relation", system), 103);

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1743,7 +1743,7 @@ public class ExamplesAndValidationTest {
             @Test
             void invalid() {
                 makeValidHypothesis(entity, relation, relationEdge);
-                testInvalid("NISTHypothesis.invalid (event and event edge does not referenced in hypothesis): " +
+                testInvalid("NISTHypothesis.invalid (event and event edge is not referenced in hypothesis): " +
                         "All KEs in model must be referenced by hypothesis");
             }
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1825,6 +1825,63 @@ public class ExamplesAndValidationTest {
                         "event or relation with at least one edge.");
             }
         }
+
+        // Clusters must be homogeneous by base class (Entity, Event, or Relation)
+        @Nested
+        class HypothesisClustersMustBeHomogeneous {
+
+            @Test
+            void invalid() {
+
+                final Resource relation = makeRelation(model, getUri("relation-1"), system);
+                final Resource relationCluster = makeClusterWithPrototype(model, getClusterUri(), relation,
+                        "Relation", system);
+
+                markImportance(relationCluster, 103);
+                markJustification(addType(relation, SeedlingOntology.GeneralAffiliation_APORA), justification);
+
+                final Resource relationEdge = markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliate,
+                        entity, system, 1d, getAssertionUri());
+                markImportance(relationEdge, 102);
+
+                // create event cluster member to add to relation cluster
+                final Resource eventMember = makeEvent(model, getUri("event-member-1"), system);
+                markJustification(addType(eventMember, SeedlingOntology.Conflict_Attack), justification);
+
+                //add invalid event cluster member to relation cluster
+                markAsPossibleClusterMember(model, eventMember, relationCluster, 1d, system);
+
+                makeValidHypothesis(entity, event, eventEdge, eventMember, relation, relationEdge);
+                testInvalid("NISTHypothesis.invalid: Clusters must be homogeneous by base class " +
+                        "(Entity, Event, or Relation).");
+            }
+
+            @Test
+            void valid() {
+
+                final Resource relation = makeRelation(model, getUri("relation-1"), system);
+                final Resource relationCluster = makeClusterWithPrototype(model, getClusterUri(), relation,
+                        "Relation", system);
+
+                markImportance(relationCluster, 103);
+                markJustification(addType(relation, SeedlingOntology.GeneralAffiliation_APORA), justification);
+
+                final Resource relationEdge = markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliate,
+                        entity, system, 1d, getAssertionUri());
+                markImportance(relationEdge, 102);
+
+                // create relation cluster member to add to relation cluster
+                final Resource relationMember = makeRelation(model, getUri("relation-member-1"), system);
+                markJustification(addType(relationMember, SeedlingOntology.GeneralAffiliation_APORA), justification);
+
+                //add valid relation cluster member to relation cluster
+                markAsPossibleClusterMember(model, relationMember, relationCluster, 1d, system);
+
+                makeValidHypothesis(entity, event, eventEdge, relation, relationEdge, relationMember);
+                testValid("NISTHypothesis.valid: Clusters must be homogeneous by base class " +
+                        "(Entity, Event, or Relation)");
+            }
+        }
     }
 
     /**

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1832,20 +1832,27 @@ public class ExamplesAndValidationTest {
         // Clusters must be homogeneous by base class (Entity, Event, or Relation)
         @Nested
         class HypothesisClustersMustBeHomogeneous {
+            Resource relation;
+            Resource relationEdge;
+            Resource relationCluster;
 
-            @Test
-            void invalid() {
+            @BeforeEach
+            void setup() {
+                relation = makeRelation(model, getUri("relation-1"), system);
 
-                final Resource relation = makeRelation(model, getUri("relation-1"), system);
-                final Resource relationCluster = makeClusterWithPrototype(model, getClusterUri(), relation,
+                relationCluster = makeClusterWithPrototype(model, getClusterUri(), relation,
                         "Relation", system);
 
                 markImportance(relationCluster, 103);
                 markJustification(addType(relation, SeedlingOntology.GeneralAffiliation_APORA), justification);
 
-                final Resource relationEdge = markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliate,
+                relationEdge = markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliate,
                         entity, system, 1d, getAssertionUri());
                 markImportance(relationEdge, 102);
+            }
+
+            @Test
+            void invalid() {
 
                 // create event cluster member to add to relation cluster
                 final Resource eventMember = makeEvent(model, getUri("event-member-1"), system);
@@ -1861,17 +1868,6 @@ public class ExamplesAndValidationTest {
 
             @Test
             void valid() {
-
-                final Resource relation = makeRelation(model, getUri("relation-1"), system);
-                final Resource relationCluster = makeClusterWithPrototype(model, getClusterUri(), relation,
-                        "Relation", system);
-
-                markImportance(relationCluster, 103);
-                markJustification(addType(relation, SeedlingOntology.GeneralAffiliation_APORA), justification);
-
-                final Resource relationEdge = markAsArgument(model, relation, SeedlingOntology.GeneralAffiliation_APORA_Affiliate,
-                        entity, system, 1d, getAssertionUri());
-                markImportance(relationEdge, 102);
 
                 // create relation cluster member to add to relation cluster
                 final Resource relationMember = makeRelation(model, getUri("relation-member-1"), system);

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1539,8 +1539,8 @@ public class ExamplesAndValidationTest {
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
                 makeValidHypothesis(entity, newEntity, event, eventEdge);
 
-                testInvalid("NISTHypothesis.invalid: Each entity cluster in the hypothesis graph must have " +
-                        "exactly one handle");
+                testInvalid("NISTHypothesis.invalid (no handle exists): Each entity cluster in the hypothesis " +
+                        "graph must have exactly one handle");
             }
 
             @Test
@@ -1554,8 +1554,8 @@ public class ExamplesAndValidationTest {
                 markJustification(addType(newEntity, SeedlingOntology.Person), justification);
                 makeValidHypothesis(entity, newEntity, event, eventEdge);
 
-                testInvalid("NISTHypothesis.invalid: Each entity cluster in the hypothesis graph must have " +
-                            "exactly one handle");
+                testInvalid("NISTHypothesis.invalid (multiple handles exist): Each entity cluster in the " +
+                        "hypothesis graph must have exactly one handle");
             }
 
             @Test
@@ -1575,8 +1575,8 @@ public class ExamplesAndValidationTest {
             void invalid() {
                 //invalid hypothesis, no importance value
                 makeHypothesis(model, getUri("hypothesis-1"), ImmutableSet.of(entity, event, eventEdge), system);
-                testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have exactly one" +
-                        " hypothesis importance value");
+                testInvalid("NISTHypothesis.invalid (hypothesis has no importance value): Each hypothesis " +
+                        "graph must have exactly one hypothesis importance value");
             }
             @Test
             void valid() {
@@ -1618,16 +1618,16 @@ public class ExamplesAndValidationTest {
             void invalidEvent() {
                 //invalid event cluster, no importance value
                 markImportance(relationCluster, 99);
-                testInvalid("NISTHypothesis.invalid: Each event or relation (cluster) in the hypothesis must " +
-                        "have exactly one importance value");
+                testInvalid("NISTHypothesis.invalid (event cluster has no importance value): Each event or " +
+                        "relation (cluster) in the hypothesis must have exactly one importance value");
             }
 
             @Test
             void invalidRelation() {
                 //invalid relation cluster, no importance value
                 markImportance(eventCluster, 88);
-                testInvalid("NISTHypothesis.invalid: Each event or relation (cluster) in the hypothesis must " +
-                        "have exactly one importance value");
+                testInvalid("NISTHypothesis.invalid (relation cluster has no importance value): Each event or " +
+                        "relation (cluster) in the hypothesis must have exactly one importance value");
             }
 
             @Test
@@ -1665,8 +1665,8 @@ public class ExamplesAndValidationTest {
 
                 makeValidHypothesis(entity, event, eventEdge, relation, invalidEventEdge);
 
-                testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
-                        "edge importance value");
+                testInvalid("NISTHypothesis.invalid (event edge has no importance value): Each edge KE in the " +
+                        "hypothesis graph must have exactly one edge importance value");
             }
 
             @Test
@@ -1678,8 +1678,8 @@ public class ExamplesAndValidationTest {
 
                 makeValidHypothesis(entity, event, eventEdge, relation, invalidRelationEdge);
 
-                testInvalid("NISTHypothesis.invalid: Each edge KE in the hypothesis graph must have exactly one " +
-                        "edge importance value");
+                testInvalid("NISTHypothesis.invalid (relation edge has no importance value): Each edge KE in the " +
+                        "hypothesis graph must have exactly one edge importance value");
             }
 
             @Test
@@ -1687,8 +1687,8 @@ public class ExamplesAndValidationTest {
 
                 makeValidHypothesis(entity, event, eventEdge, relation);
 
-                testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
-                        "edge importance value");
+                testValid("NISTHypothesis.valid (event edge has importance value): Each edge KE in the " +
+                        "hypothesis graph must have exactly one edge importance value");
             }
 
             @Test
@@ -1701,8 +1701,8 @@ public class ExamplesAndValidationTest {
 
                 makeValidHypothesis(entity, event, eventEdge, relation, relationEdge);
 
-                testValid("NISTHypothesis.valid: Each edge KE in the hypothesis graph must have exactly one " +
-                        "edge importance value");
+                testValid("NISTHypothesis.valid (relation edge has importance value): Each edge KE in the " +
+                        "hypothesis graph must have exactly one edge importance value");
             }
         }
 
@@ -1713,7 +1713,8 @@ public class ExamplesAndValidationTest {
             void invalid() {
                 Resource fakeEntity = model.createResource(getEntityUri());
                 makeValidHypothesis(fakeEntity, entity, event, eventEdge);
-                testInvalid("NISTHypothesis.invalid: All KEs referenced by hypothesis must be defined in model");
+                testInvalid("NISTHypothesis.invalid (entity is not defined): All KEs referenced by hypothesis " +
+                        "must be defined in model");
             }
 
             @Test
@@ -1742,7 +1743,8 @@ public class ExamplesAndValidationTest {
             @Test
             void invalid() {
                 makeValidHypothesis(entity, relation, relationEdge);
-                testInvalid("NISTHypothesis.invalid: All KEs in model must be referenced by hypothesis");
+                testInvalid("NISTHypothesis.invalid (event and event edge does not referenced in hypothesis): " +
+                        "All KEs in model must be referenced by hypothesis");
             }
 
             @Test
@@ -1766,8 +1768,8 @@ public class ExamplesAndValidationTest {
                 entityCluster = makeClusterWithPrototype(model, getClusterUri(), entity, "handle", system);
                 markJustification(addType(entity, SeedlingOntology.Person), justification);
                 makeValidHypothesis(entity);
-                testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have at least one " +
-                        "event or relation with at least one edge.");
+                testInvalid("NISTHypothesis.invalid (no event or relation exists): Each hypothesis graph must " +
+                        "have at least one event or relation with at least one edge.");
             }
 
             @Test
@@ -1782,8 +1784,8 @@ public class ExamplesAndValidationTest {
                 markImportance(invalidRelationEdge, 102);
 
                 makeValidHypothesis(entity, event, eventEdge, relation, invalidRelationEdge);
-                testInvalid("NISTHypothesis.invalid: Each hypothesis graph must have at least one event " +
-                        "or relation with at least one edge.");
+                testInvalid("NISTHypothesis.invalid (event has invalid relation edge): Each hypothesis graph " +
+                        "must have at least one event or relation with at least one edge.");
             }
 
             // TODO This test case needs to be updated and @Test needs to be added back in  once we decide on the
@@ -1798,16 +1800,16 @@ public class ExamplesAndValidationTest {
                 markImportance(relationEdge, 102);
 
                 makeValidHypothesis(entity, event, eventEdge, relation, relationEdge);
-                testValid("NISTHypothesis.valid: Each hypothesis graph must have at least one event " +
-                        "or relation with at least one edge.");
+                testValid("NISTHypothesis.valid (relation has relation edge): Each hypothesis graph must have " +
+                        "at least one event or relation with at least one edge.");
             }
 
             @Test
             void validEventAndEventEdge() {
 
                 makeValidHypothesis(entity, event, eventEdge);
-                testValid("NISTHypothesis.valid: Each hypothesis graph must have at least one " +
-                        "event or relation with at least one edge.");
+                testValid("NISTHypothesis.valid (event has event edge): Each hypothesis graph must have " +
+                        "at least one event or relation with at least one edge.");
             }
 
             @Test
@@ -1822,8 +1824,8 @@ public class ExamplesAndValidationTest {
                 markImportance(relationEdge, 102);
 
                 makeValidHypothesis(entity, event, eventEdge, relation, relationEdge);
-                testValid("NISTHypothesis.valid: Each hypothesis graph must have at least one " +
-                        "event or relation with at least one edge.");
+                testValid("NISTHypothesis.valid (event has event edge and relation has relation edge): Each " +
+                        "hypothesis graph must have at least one event or relation with at least one edge.");
             }
         }
 
@@ -1853,8 +1855,8 @@ public class ExamplesAndValidationTest {
                 markAsPossibleClusterMember(model, eventMember, relationCluster, 1d, system);
 
                 makeValidHypothesis(entity, event, eventEdge, eventMember, relation, relationEdge);
-                testInvalid("NISTHypothesis.invalid: Clusters must be homogeneous by base class " +
-                        "(Entity, Event, or Relation).");
+                testInvalid("NISTHypothesis.invalid (event exists in relation cluster): Clusters must be " +
+                        "homogeneous by base class (Entity, Event, or Relation).");
             }
 
             @Test


### PR DESCRIPTION
- Created hypothesis restriction to enforce all clusters must be homogeneous by base class (Entity, Event, or Relation)
- Created valid and invalid test cases to validate the new aforementioned hypothesis restriction
- Updated all other hypothesis test cases that were impacted by the required importance value
- Updated all Hypothesis examples to include more detailed notification strings to help disambiguate output for https://nextcentury.atlassian.net/wiki/spaces/AIDAC/pages/507347434/Example+AIF+that+pass+and+fail+NIST+validations