### PR TITLE
Upgrade to Kotlin 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 
     <properties>
-        <kotlin.version>1.2.30</kotlin.version>
+        <kotlin.version>1.3.21</kotlin.version>
     </properties>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.github.microutils</groupId>
             <artifactId>kotlin-logging</artifactId>
-            <version>1.4.9</version>
+            <version>1.6.26</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
@@ -37,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This fixes a deprecated Kotlin standard library dependency (used by the ColdStart converter)