### PR TITLE
AIDA-688:  Update ScalingTest to generate valid/invalid LDC restricted AIF

### DIFF
--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -2,8 +2,8 @@ package com.ncc.aif;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Resources;
 import org.apache.jena.ext.com.google.common.collect.ImmutableList;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
@@ -13,12 +13,8 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.tdb.TDBFactory;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.SKOS;
-import org.apache.jena.vocabulary.XSD;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
 
@@ -26,7 +22,7 @@ import static com.ncc.aif.AIFUtils.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Test to see how large we can scale AIF with the LDC Seedling ontology.  AIF uses a Jena-based model,
+ * Test to see how large we can scale AIF with the LDC ontology (LO).  AIF uses a Jena-based model,
  * and so we rely on that to determine how large it can get.  Change whether you are using a memory based model
  * or a disk-based model (TDB) below in the line that defines modelTypeToUse.  MEMORY is faster, but
  * is more limited;  TDB is slower but can handle more statements.
@@ -54,6 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The smaller ones are difficult to read, the large ones do not use prefixes. turtle_pretty is readable and not too large.
  * By default, this class runs a scaling test using the Turtle Pretty output type.
  * <p>
+ * This class can generate either valid or invalid restricted AIF output, as specified by the -i switch.  Invalid output
+ * can be configured by tweaking the FREQ_* class constants.  The higher the number, the more often that particular
+ * restriction will be violated by the generated TTL file.
  * Run with:
  * %  mvn exec:java -Dexec.mainClass="com.ncc.aif.ScalingTest" -Dexec.classpathScope="test" -Dexec.args="[arguments]"
  * where arguments are:
@@ -62,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *       -o   run a single test on different output types (incompatible with -s and -v)
  *       -t   use tdb model (default is to use in-memory)
  *       -v   do validation (default is to not do validation, incompatible with -o)
+ *       -i   generate invalid output (default is valid output)
  * </pre>
  */
 public class ScalingTest {
@@ -77,19 +77,62 @@ public class ScalingTest {
     private int entityIndex = 1;
     private int eventIndex = 1;
     private int assertionIndex = 1;
+    private int clusterCount = 0;
 
-    private static final String NAMESPACE = "https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/SeedlingOntology";
+    private static final String NAMESPACE = "https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/LDCOntology";
+    private static final boolean ALLOW_NUMERIC_TYPES = false;
 
     private final Random r = new Random();
     private List<Resource> entityResourceList = null;
 
-    private final String filename = "scalingdata.ttl";
+    private String filename = "scalingdata-" + entityCount + "x" + eventCount + ".ttl";
 
     // Whether to use in memory or disk based.
     // Note:  TDB2 requires transactions, which we do not do!  Do not use it!
     private enum MODEL_TYPE {
         MEMORY, TDB
     }
+
+    // These NIST restrictions correspond to (and should be updated from) com/ncc/aif/ExamplesAndValidationTest.java.
+    private enum NIST_RESTRICTION {
+        RestrictJustification_Edges,    // Edge justification must be aida:CompoundJustification
+        RestrictJustification_Compound, // CompoundJustification must be used only for justifications of argument assertions
+        EdgeJustificationLimit,         // Each edge justification is limited to either one or two spans
+        PreventShotVideo,               // Video must use aida:KeyFrameVideoJustification. Remove ShotVideoJustification
+        FlatClusters,                   // Members of clusters are entity objects, relation objects, and event objects (not clusters)
+        EverythingClustered,            // Entity, Relation, and Event object is required to be part of at least one cluster.
+        ConfidenceValueRange,           // Each confidence value must be between 0 and 1
+        ClusterHasIRI,                  // Entity, Relation, and Event clusters must have IRI
+        JustifyTypeAssertions,          // Each entity/relation/event type statement must have at least one justification
+        NameMaxLength                   // Each entity/filler name string is limited to 256 UTF-8 characters
+    }
+
+    // Tweak these values to introduce more/fewer invalid content in the generated KB.
+    private static final double FREQ_RestrictJustification_Edges = 0.3;
+    private static final double FREQ_RestrictJustification_Compound = 0.3;
+    private static final double FREQ_EdgeJustificationLimit = 0.3;
+    private static final double FREQ_PreventShotVideo = 0.3;
+    private static final double FREQ_FlatClusters = 0.3;
+    private static final double FREQ_EverythingClustered = 0.3;
+    private static final double FREQ_ConfidenceValueRange = 0.3;
+    private static final double FREQ_ClusterHasIRI = 0.3;
+    private static final double FREQ_JustifyTypeAssertions = 0.3;
+    private static final double FREQ_NameMaxLength = 0.3;
+
+    // Maps each restriction to the frequency that that restriction will cause an invalidity in the KB.
+    private static final ImmutableMap<NIST_RESTRICTION, Double> CHAOS_MAP =
+            ImmutableMap.<NIST_RESTRICTION, Double>builder()
+                    .put(NIST_RESTRICTION.RestrictJustification_Edges, FREQ_RestrictJustification_Edges)
+                    .put(NIST_RESTRICTION.RestrictJustification_Compound, FREQ_RestrictJustification_Compound)
+                    .put(NIST_RESTRICTION.EdgeJustificationLimit, FREQ_EdgeJustificationLimit)
+                    .put(NIST_RESTRICTION.PreventShotVideo, FREQ_PreventShotVideo)
+                    .put(NIST_RESTRICTION.FlatClusters, FREQ_FlatClusters)
+                    .put(NIST_RESTRICTION.EverythingClustered, FREQ_EverythingClustered)
+                    .put(NIST_RESTRICTION.ConfidenceValueRange, FREQ_ConfidenceValueRange)
+                    .put(NIST_RESTRICTION.ClusterHasIRI, FREQ_ClusterHasIRI)
+                    .put(NIST_RESTRICTION.JustifyTypeAssertions, FREQ_JustifyTypeAssertions)
+                    .put(NIST_RESTRICTION.NameMaxLength, FREQ_NameMaxLength)
+                    .build();
 
     // What output format to use, whether turtle pretty, or flat, or ntriple, or blocks
     // See RDFFormat for a definition of these.
@@ -122,6 +165,9 @@ public class ScalingTest {
     // Set this to false to run a single, unscaled test
     private boolean runScalingTest = true;
 
+    // Set this to false to introduce some invalid elements into the generated model
+    private boolean generateValidModel = true;
+
     /**
      * Main function.  See class description for arguments.
      */
@@ -137,6 +183,7 @@ public class ScalingTest {
         if (args.contains("-o")) {
             useMultipleOutputs = true;
             runScalingTest = false;
+            filename = "scalingdata.ttl";
             if (args.contains("-s")) {
                 System.err.println("Please use only one of -o and -s.");
                 System.exit(1);
@@ -153,6 +200,11 @@ public class ScalingTest {
 
         if (args.contains("-v")) {
             performValidation = true;
+        }
+
+        if (args.contains("-i")) {
+            generateValidModel = false;
+            filename = filename.replace(".ttl", "-invalid.ttl");
         }
 
         if (useMultipleOutputs && performValidation) {
@@ -221,31 +273,46 @@ public class ScalingTest {
     }
 
     private void addEntity() {
-        // Add an entity
+        // Add an entity and add it to a cluster
         Resource entityResource = makeEntity(model, getEntityUri(), system);
+        if (preserveValidity(NIST_RESTRICTION.EverythingClustered)) {
+            makeClusterWithPrototype(model, getClusterUri(), entityResource, system);
+        }
+
         entityResourceList.add(entityResource);
 
         // sometimes add hasName, textValue, or numericValue
+        boolean createLongString = checkChaos(NIST_RESTRICTION.NameMaxLength);
         double rand = r.nextDouble();
         Resource typeToUse;
-        if (rand < 0.15) {
-            markName(entityResource, getRandomString(5));
-            typeToUse = SeedlingOntology.Person;
+        if (rand < 0.15 || createLongString) {
+            markName(entityResource, getRandomString(createLongString ? 257 : 7));
+            typeToUse = LDCOntology.Person;
         } else if (rand < 0.3) {
             markTextValue(entityResource, getRandomString(7));
-            typeToUse = SeedlingOntology.Results;
+            typeToUse = LDCOntology.Results;
         } else if (rand < 0.4) {
-            markNumericValueAsDouble(entityResource, r.nextDouble());
-            typeToUse = SeedlingOntology.Age;
+            // LDC doesn't have numeric values, but other ontologies might, so keep this here
+            if (ALLOW_NUMERIC_TYPES) {
+                markNumericValueAsDouble(entityResource, r.nextDouble());
+                typeToUse = LDCOntology.NumericalValue_Number_Number;
+            } else {
+                markTextValue(entityResource, getRandomString(7));
+                typeToUse = LDCOntology.Results;
+            }
         } else {
-            typeToUse = SeedlingOntology.Person;
+            typeToUse = LDCOntology.Person;
         }
 
         // Set the type
         Resource typeAssertion = markType(model, getAssertionUri(), entityResource,
                 typeToUse, system, 1.0);
 
-        addJustificationAndPrivateData(typeAssertion);
+        if (preserveValidity(NIST_RESTRICTION.RestrictJustification_Compound)) {
+            addJustificationAndPrivateData(typeAssertion);
+        } else {
+            addEdgeJustificationAndPrivateData(typeAssertion);
+        }
     }
 
     private void addEventOrRelation() {
@@ -259,62 +326,114 @@ public class ScalingTest {
     }
 
     private void addEvent() {
-        // Add an event
+        // Add an event and add it to a cluster
         Resource eventResource = makeEvent(model, getEventUri(), system);
+        Resource eventCluster = makeClusterWithPrototype(model, getClusterUri(), eventResource, system);
+
+        if (checkChaos(NIST_RESTRICTION.FlatClusters)) {
+            Resource entityCluster = makeClusterWithPrototype(model, getClusterUri(), getRandomEntity(), "handle", system);
+            markAsPossibleClusterMember(model, eventCluster, entityCluster, .5, system);
+        }
 
         // Set the type
-        Resource typeResource = SeedlingOntology.Business_DeclareBankruptcy;
+        Resource typeResource = LDCOntology.Conflict_Attack_AirstrikeMissileStrike;
         Resource typeAssertion = markType(model, getAssertionUri(), eventResource, typeResource, system, 1.0);
 
         addJustificationAndPrivateData(typeAssertion);
 
         // Make two arguments
         Resource argument = markAsArgument(model, eventResource,
-                SeedlingOntology.Business_DeclareBankruptcy_Place,
+                LDCOntology.Conflict_Attack_AirstrikeMissileStrike_Place,
                 getRandomEntity(), system, 0.785, getAssertionUri());
-        addJustificationAndPrivateData(argument);
+        if (preserveValidity(NIST_RESTRICTION.RestrictJustification_Edges)) {
+            addEdgeJustificationAndPrivateData(argument);
+        } else {
+            addJustificationAndPrivateData(argument);
+        }
 
         Resource argumentTwo = markAsArgument(model, eventResource,
-                SeedlingOntology.Business_DeclareBankruptcy_Organization,
+                LDCOntology.Conflict_Attack_AirstrikeMissileStrike_Attacker,
                 getRandomEntity(), system, 0.785, getAssertionUri());
-        addJustificationAndPrivateData(argumentTwo);
-
+        addEdgeJustificationAndPrivateData(argumentTwo);
     }
 
     private void addRelation() {
-        // Add a relation
-        Resource eventResource = makeRelation(model, getEventUri(), system);
+        // Add a relation and add it to a cluster
+        Resource relationResource = makeRelation(model, getEventUri(), system);
+        makeClusterWithPrototype(model,
+                preserveValidity(NIST_RESTRICTION.ClusterHasIRI) ? getClusterUri() : null,
+                relationResource, system);
 
         // Set the type
-        Resource typeResource = SeedlingOntology.Physical_Resident;
-        Resource typeAssertion = markType(model, getAssertionUri(), eventResource, typeResource, system, 1.0);
+        Resource typeResource = LDCOntology.Physical_Resident_Resident;
+        Resource typeAssertion = markType(model, getAssertionUri(), relationResource, typeResource, system, 1.0);
 
         addJustificationAndPrivateData(typeAssertion);
 
         // Make two arguments
-        Resource argument = markAsArgument(model, eventResource,
-                SeedlingOntology.Physical_Resident_Place,
+        Resource argument = markAsArgument(model, relationResource,
+                LDCOntology.Physical_Resident_Resident_Place,
                 getRandomEntity(), system, 0.785, getAssertionUri());
-        addJustificationAndPrivateData(argument);
+        if (preserveValidity(NIST_RESTRICTION.RestrictJustification_Edges)) {
+            addEdgeJustificationAndPrivateData(argument);
+        } else {
+            addJustificationAndPrivateData(argument);
+        }
 
-        Resource argumentTwo = markAsArgument(model, eventResource,
-                SeedlingOntology.Physical_Resident_Resident,
+        Resource argumentTwo = markAsArgument(model, relationResource,
+                LDCOntology.Physical_Resident_Resident_Resident,
                 getRandomEntity(), system, 0.785, getAssertionUri());
-        addJustificationAndPrivateData(argumentTwo);
+        addEdgeJustificationAndPrivateData(argumentTwo);
     }
 
     private void addJustificationAndPrivateData(Resource resource) {
         String docId = getRandomDocId();
 
         // Justify the type assertion
-        markTextJustification(model, ImmutableSet.of(resource), docId, 1029, 1033, system, 0.973);
+        if (preserveValidity(NIST_RESTRICTION.JustifyTypeAssertions)) {
+            markTextJustification(model, resource, docId, 1029, 1033, system,
+                    preserveValidity(NIST_RESTRICTION.ConfidenceValueRange) ? 0.973 : 1.973);
+        }
 
         // Add some private data
         markPrivateData(model, resource, "{ 'provenance' : '" + docId + "' }", system);
     }
 
-    private final ValidateAIF seedlingValidator = ValidateAIF.createForDomainOntologySource(
-            Resources.asCharSource(Resources.getResource("com/ncc/aif/ontologies/SeedlingOntology"), StandardCharsets.UTF_8));
+    private void addEdgeJustificationAndPrivateData(Resource resource) {
+        String docId = getRandomDocId();
+
+        // Justify the edge
+        final Resource justification = preserveValidity(NIST_RESTRICTION.PreventShotVideo) ?
+                makeTextJustification(model, docId, 1029, 1033, system, 0.973) :
+                markShotVideoJustification(model, getRandomEntity(), "source1", "shotId", system, 1.0);
+        Resource compound;
+        if (checkChaos(NIST_RESTRICTION.EdgeJustificationLimit)) {
+            final Resource justification2 = makeTextJustification(model, docId, 1055, 1071, system, 0.677);
+            final Resource justification3 = makeTextJustification(model, docId, 1102, 1159, system, 0.881);
+            compound = markCompoundJustification(model,
+                    ImmutableSet.of(resource), ImmutableSet.of(justification, justification2, justification3), system, 1.0);
+        } else {
+            compound = markCompoundJustification(model,
+                    ImmutableSet.of(resource), ImmutableSet.of(justification), system,
+                    preserveValidity(NIST_RESTRICTION.ConfidenceValueRange) ? 1.0 : -1.0);
+        }
+        markJustification(resource, compound);
+
+        // Add some private data
+        markPrivateData(model, resource, "{ 'provenance' : '" + docId + "' }", system);
+    }
+
+    // Returns true when invalid content should be generated
+    private boolean checkChaos(NIST_RESTRICTION restriction) {
+        return !preserveValidity(restriction);
+    }
+
+    // Returns true when invalid content should be generated
+    private boolean preserveValidity(NIST_RESTRICTION restriction) {
+        return (generateValidModel || r.nextDouble() > CHAOS_MAP.get(restriction));
+    }
+
+    private final ValidateAIF ldcValidator = ValidateAIF.createForLDCOntology(ValidateAIF.Restriction.NIST);
 
     // we dump the test name and the model in Turtle format so that whenever the user
     // runs the tests, they will also get the examples
@@ -323,7 +442,7 @@ public class ScalingTest {
             RDFDataMgr.write(Files.newOutputStream(Paths.get(filename)), model, RDFFormat.TURTLE_PRETTY);
             if (performValidation) {
                 System.out.println("\nDoing validation.  Validation errors (if any) follow:");
-                assertTrue(seedlingValidator.validateKB(model));
+                assertTrue(ldcValidator.validateKB(model));
             }
         } catch (Exception e) {
             System.err.println("Unable to write to file " + filename + " " + e.getMessage());
@@ -372,14 +491,10 @@ public class ScalingTest {
                 System.exit(2);
         }
 
-        // final Model model = ModelFactory.createDefaultModel();
         // adding namespace prefixes makes the Turtle output more readable
-        model.setNsPrefix("rdf", RDF.uri);
-        model.setNsPrefix("xsd", XSD.getURI());
-        model.setNsPrefix("aida", AidaAnnotationOntology.NAMESPACE);
+        addStandardNamespaces(model);
         model.setNsPrefix("ldcOnt", NAMESPACE);
         model.setNsPrefix("ldc", LDC_NS);
-        model.setNsPrefix("skos", SKOS.uri);
     }
 
     private static String getUri(String localName) {
@@ -392,6 +507,10 @@ public class ScalingTest {
 
     private String getEventUri() {
         return getUri("event-" + eventIndex++);
+    }
+
+    private String getClusterUri() {
+        return getUri("cluster-" + clusterCount++);
     }
 
     private String getAssertionUri() {

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -107,7 +107,8 @@ public class ScalingTest {
         NameMaxLength                   // Each entity/filler name string is limited to 256 UTF-8 characters
     }
 
-    // Tweak these values to introduce more/fewer invalid content in the generated KB.
+    // Increase/decrease these values (scaled from 0 to 1) to introduce more/less invalid content in the generated KB.
+    // These will only have an effect if generateValidModel is false, as set via -the -i program argument.
     private static final double FREQ_RestrictJustification_Edges = 0.3;
     private static final double FREQ_RestrictJustification_Compound = 0.3;
     private static final double FREQ_EdgeJustificationLimit = 0.3;
@@ -282,7 +283,7 @@ public class ScalingTest {
         entityResourceList.add(entityResource);
 
         // sometimes add hasName, textValue, or numericValue
-        boolean createLongString = checkChaos(NIST_RESTRICTION.NameMaxLength);
+        boolean createLongString = introduceChaos(NIST_RESTRICTION.NameMaxLength);
         double rand = r.nextDouble();
         Resource typeToUse;
         if (rand < 0.15 || createLongString) {
@@ -330,7 +331,7 @@ public class ScalingTest {
         Resource eventResource = makeEvent(model, getEventUri(), system);
         Resource eventCluster = makeClusterWithPrototype(model, getClusterUri(), eventResource, system);
 
-        if (checkChaos(NIST_RESTRICTION.FlatClusters)) {
+        if (introduceChaos(NIST_RESTRICTION.FlatClusters)) {
             Resource entityCluster = makeClusterWithPrototype(model, getClusterUri(), getRandomEntity(), "handle", system);
             markAsPossibleClusterMember(model, eventCluster, entityCluster, .5, system);
         }
@@ -407,7 +408,7 @@ public class ScalingTest {
                 makeTextJustification(model, docId, 1029, 1033, system, 0.973) :
                 markShotVideoJustification(model, getRandomEntity(), "source1", "shotId", system, 1.0);
         Resource compound;
-        if (checkChaos(NIST_RESTRICTION.EdgeJustificationLimit)) {
+        if (introduceChaos(NIST_RESTRICTION.EdgeJustificationLimit)) {
             final Resource justification2 = makeTextJustification(model, docId, 1055, 1071, system, 0.677);
             final Resource justification3 = makeTextJustification(model, docId, 1102, 1159, system, 0.881);
             compound = markCompoundJustification(model,
@@ -424,11 +425,11 @@ public class ScalingTest {
     }
 
     // Returns true when invalid content should be generated
-    private boolean checkChaos(NIST_RESTRICTION restriction) {
+    private boolean introduceChaos(NIST_RESTRICTION restriction) {
         return !preserveValidity(restriction);
     }
 
-    // Returns true when invalid content should be generated
+    // Returns true when valid content should be generated
     private boolean preserveValidity(NIST_RESTRICTION restriction) {
         return (generateValidModel || r.nextDouble() > CHAOS_MAP.get(restriction));
     }


### PR DESCRIPTION
Updated the ScalingTest to use LDC Ontology and generate valid or invalid restricted AIF.

To test, generate valid and invalid files and validate with the AIF validator (saving invalid results to a file).  Inspect the report from the invalid file and ensure that types and numbers of violations are in line with expectations.  Note that validation time has increased significantly with the latest NIST restrictions.  On my laptop, validating a model with 1000 entities and 300 events took 26 minutes.

I'm hoping that as part of the review process, we can come up with better/reasonable frequency constants (FREQ_*) for each of the restrictions.  I have set them all to a "default" value of 0.3.  Note that this number doesn't necessarily mean "30% of the time, the given restriction will be violated," as some of the restrictions interrelate.

Note that AIDA-688 talks about generating models of "significant complexity," which basically means, "models that make sense."  That part of the issue has been removed from this issue for several reasons:
- This ticket was time-boxed to 5 story points
- As part of AIDA-553, I will be creating a large "model that makes sense" generated from the LDC Annotations (multiplied by 1000 or so)
- Generating a model that resembles that of a researcher isn't really in my wheelhouse

Once a new model is created in AIDA-553 from the LDC Annotations, we can decide if that model satisfies the need originally stated in AIDA-688 or if we need to create a new ticket.