### PR TITLE
Aida 716

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -223,7 +223,7 @@ aida:JustificationSourceDocumentShape
     sh:property [
         sh:path aida:sourceDocument ;
         sh:minCount 1 ;
-        sh:message "Justifications require source and a sourceDocument" ;
+        sh:message "Justifications require a sourceDocument" ;
     ]
     .
 

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -214,7 +214,7 @@ aida:RequiredJustificationPropertyShape
    sh:message "Type assertions must have at least one justification" .
 
 #########################
-# Justifications require source and a source document
+# Justifications require a source document and a source
 # The source restriction is defined on the aida:SharedJustificationShape in the aida_ontology.shacl
 #------------------------
 aida:JustificationSourceShape

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -217,7 +217,7 @@ aida:RequiredJustificationPropertyShape
 # Justifications require a source document and a source
 # The source restriction is defined on the aida:SharedJustificationShape in the aida_ontology.shacl
 #------------------------
-aida:JustificationSourceShape
+aida:JustificationSourceDocumentShape
     a sh:NodeShape ;
     sh:targetClass aida:Justification ;
     sh:property [

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -214,6 +214,20 @@ aida:RequiredJustificationPropertyShape
    sh:message "Type assertions must have at least one justification" .
 
 #########################
+# Justifications require source and a source document
+# The source restriction is defined on the aida:SharedJustificationShape in the aida_ontology.shacl
+#------------------------
+aida:JustificationSourceShape
+    a sh:NodeShape ;
+    sh:targetObjectsOf aida:justifiedBy ;
+    sh:property [
+        sh:path aida:sourceDocument ;
+        sh:minCount 1 ;
+        sh:message "Justifications require source and a sourceDocument" ;
+    ]
+    .
+
+#########################
 # Each entity/filler name string is limited to 256 UTF-8 characters
 #------------------------
 aida:NamePropertyShape

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -219,7 +219,7 @@ aida:RequiredJustificationPropertyShape
 #------------------------
 aida:JustificationSourceShape
     a sh:NodeShape ;
-    sh:targetClass aida:TextJustification, aida:ImageJustification, aida:AudioJustification, aida:KeyFrameVideoJustification, aida:ShotVideoJustification;
+    sh:targetClass aida:Justification ;
     sh:property [
         sh:path aida:sourceDocument ;
         sh:minCount 1 ;

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -219,7 +219,7 @@ aida:RequiredJustificationPropertyShape
 #------------------------
 aida:JustificationSourceShape
     a sh:NodeShape ;
-    sh:targetObjectsOf aida:justifiedBy ;
+    sh:targetClass aida:TextJustification, aida:ImageJustification, aida:AudioJustification, aida:KeyFrameVideoJustification, aida:ShotVideoJustification;
     sh:property [
         sh:path aida:sourceDocument ;
         sh:minCount 1 ;

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1523,7 +1523,7 @@ public class ExamplesAndValidationTest {
             }
         }
 
-        // Justifications require sourceDocument and a source for a span
+        // Justifications require a source document and a source
         @Nested
         class JustificationSourceAndSourceDocument {
             Resource newJustification;
@@ -1552,7 +1552,7 @@ public class ExamplesAndValidationTest {
             void invalidNoSource() {
                 // include the source document but not the source
                 addSourceDocumentToJustification(newJustification, "HC00002ZO");
-                testInvalid("NIST.invalid (missing justification source): justifications require source document and a source");
+                testInvalid("NIST.invalid (missing justification source): justifications require a source document and source");
 
             }
 
@@ -1560,7 +1560,7 @@ public class ExamplesAndValidationTest {
             void invalidNoSourceDocument() {
                 // include the source but not the source document
                 newJustification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral("XP043002ZO"));
-                testInvalid("NIST.invalid (missing justification source document): justifications require source document and a source");
+                testInvalid("NIST.invalid (missing justification source document): justifications require a source document and source");
             }
 
             @Test
@@ -1568,7 +1568,7 @@ public class ExamplesAndValidationTest {
                 // include the source and source document
                 newJustification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral("XP043002ZO"));
                 addSourceDocumentToJustification(newJustification, "HC00002ZO");
-                testValid("NIST.valid: justifications require source document and a source");
+                testValid("NIST.valid: justifications require a source document and a source");
             }
         }
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1189,6 +1189,7 @@ public class ExamplesAndValidationTest {
         void setup() {
             typeAssertionJustification = makeTextJustification(model, "NYT_ENG_20181231",
                     42, 143, system, 0.973);
+            addSourceDocumentToJustification(typeAssertionJustification,"20181231");
 
             entity = makeEntity(model, getEntityUri(), system);
             markJustification(addType(entity, SeedlingOntology.Person), typeAssertionJustification);
@@ -1218,6 +1219,7 @@ public class ExamplesAndValidationTest {
                         SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d, getAssertionUri());
                 final Resource justification = markTextJustification(model, relationEdge,
                         "source1", 0, 4, system, 1d);
+                addSourceDocumentToJustification(justification, "source1sourceDocument");
 
                 // test event edge argument must have a compound justification
                 final Resource eventEdge = markAsArgument(model, event, SeedlingOntology.Conflict_Attack_Target,
@@ -1225,6 +1227,7 @@ public class ExamplesAndValidationTest {
                 markJustification(eventEdge, justification);
 
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource compound1 = markCompoundJustification(model,
                         ImmutableSet.of(entity, relation, event),
                         ImmutableSet.of(justification1),
@@ -1246,6 +1249,8 @@ public class ExamplesAndValidationTest {
                 final Resource relationEdge = markAsArgument(model, relation,
                         SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d);
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
+
                 final Resource compound = markCompoundJustification(model,
                         ImmutableSet.of(relationEdge),
                         ImmutableSet.of(justification1),
@@ -1272,8 +1277,11 @@ public class ExamplesAndValidationTest {
                 final Resource relationEdge = markAsArgument(model, relation,
                         SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d, getAssertionUri());
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource justification2 = makeTextJustification(model, "source1", 10, 14, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource justification3 = makeTextJustification(model, "source1", 20, 24, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource compound = markCompoundJustification(model,
                         ImmutableSet.of(relationEdge),
                         ImmutableSet.of(justification1, justification2, justification3),
@@ -1313,7 +1321,9 @@ public class ExamplesAndValidationTest {
                 final Resource relationEdge = markAsArgument(model, relation,
                         SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d);
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource justification2 = makeTextJustification(model, "source1", 10, 14, system, 1d);
+                addSourceDocumentToJustification(justification2, "source1sourceDocument");
                 final Resource compound = markCompoundJustification(model,
                         ImmutableSet.of(relationEdge),
                         ImmutableSet.of(justification1, justification2),
@@ -1333,6 +1343,7 @@ public class ExamplesAndValidationTest {
                 final Resource relationEdge = markAsArgument(model, relation,
                         SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d);
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
+                addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource compound = markCompoundJustification(model,
                         ImmutableSet.of(relationEdge),
                         ImmutableSet.of(justification1),
@@ -1352,14 +1363,18 @@ public class ExamplesAndValidationTest {
         class PreventShotVideo {
             @Test
             void invalid() {
-                markShotVideoJustification(model, entity, "source1", "shotId", system, 1d);
+                final Resource markShotVideoJustification = markShotVideoJustification(model, entity, "source1",
+                        "shotId", system, 1d);
+                addSourceDocumentToJustification(markShotVideoJustification, "source1SourceDocument");
                 testInvalid("NIST.invalid: No shot video");
             }
 
             @Test
             void valid() {
-                markKeyFrameVideoJustification(model, entity, "source1", "keyframe",
+                final Resource markKeyFrameVideoJustification = markKeyFrameVideoJustification(model, entity,
+                        "source1","keyframe",
                         new BoundingBox(new Point(0, 0), new Point(100, 100)), system, 1d);
+                addSourceDocumentToJustification(markKeyFrameVideoJustification, "source1SourceDocument");
                 testValid("NIST.valid: No shot video");
             }
         }
@@ -1527,13 +1542,17 @@ public class ExamplesAndValidationTest {
                         model.createTypedLiteral(41));
                 newJustification.addProperty(AidaAnnotationOntology.END_OFFSET_INCLUSIVE,
                         model.createTypedLiteral(143));
+
+                final Resource newEvent = makeEvent(model, getUri("event-2"), system);
+                markJustification(addType(newEvent, SeedlingOntology.Conflict_Attack), newJustification);
+                makeClusterWithPrototype(model, getClusterUri(), newEvent, system);
             }
 
             @Test
             void invalidNoSource() {
                 // include the source document but not the source
                 addSourceDocumentToJustification(newJustification, "HC00002ZO");
-                testInvalid("NIST.invalid (missing justification source and source document): justifications require source document and a source");
+                testInvalid("NIST.invalid (missing justification source): justifications require source document and a source");
 
             }
 
@@ -1549,7 +1568,7 @@ public class ExamplesAndValidationTest {
                 // include the source and source document
                 newJustification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral("XP043002ZO"));
                 addSourceDocumentToJustification(newJustification, "HC00002ZO");
-                testValid("NIST.valid: type assertions must be justified");
+                testValid("NIST.valid: justifications require source document and a source");
             }
         }
 
@@ -1574,6 +1593,8 @@ public class ExamplesAndValidationTest {
         void setup() {
             justification = makeTextJustification(model, "NYT_ENG_20181231",
                     42, 143, system, 0.973);
+            addSourceDocumentToJustification(justification, "20181231");
+
             entity = makeEntity(model, getEntityUri(), system);
             entityCluster = makeClusterWithPrototype(model, getClusterUri(), entity, "handle", system);
             markJustification(addType(entity, SeedlingOntology.Person), justification);

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1507,6 +1507,52 @@ public class ExamplesAndValidationTest {
                 testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
             }
         }
+
+        // Justifications require sourceDocument and a source for a span
+        @Nested
+        class JustificationSourceAndSourceDocument {
+            Resource newJustification;
+
+            @BeforeEach
+            void setup() {
+                // create justification from scratch
+                newJustification = model.createResource();
+                newJustification.addProperty(RDF.type, AidaAnnotationOntology.TEXT_JUSTIFICATION_CLASS);
+                if (system != null) {
+                    markSystem(newJustification, system);
+                }
+
+                markConfidence(model, newJustification, 0.973, system);
+                newJustification.addProperty(AidaAnnotationOntology.START_OFFSET,
+                        model.createTypedLiteral(41));
+                newJustification.addProperty(AidaAnnotationOntology.END_OFFSET_INCLUSIVE,
+                        model.createTypedLiteral(143));
+            }
+
+            @Test
+            void invalidNoSource() {
+                // include the source document but not the source
+                addSourceDocumentToJustification(newJustification, "HC00002ZO");
+                testInvalid("NIST.invalid (missing justification source and source document): justifications require source document and a source");
+
+            }
+
+            @Test
+            void invalidNoSourceDocument() {
+                // include the source but not the source document
+                newJustification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral("XP043002ZO"));
+                testInvalid("NIST.invalid (missing justification source document): justifications require source document and a source");
+            }
+
+            @Test
+            void valid() {
+                // include the source and source document
+                newJustification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral("XP043002ZO"));
+                addSourceDocumentToJustification(newJustification, "HC00002ZO");
+                testValid("NIST.valid: type assertions must be justified");
+            }
+        }
+
     }
 
     /**

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1279,9 +1279,9 @@ public class ExamplesAndValidationTest {
                 final Resource justification1 = makeTextJustification(model, "source1", 0, 4, system, 1d);
                 addSourceDocumentToJustification(justification1, "source1sourceDocument");
                 final Resource justification2 = makeTextJustification(model, "source1", 10, 14, system, 1d);
-                addSourceDocumentToJustification(justification1, "source1sourceDocument");
+                addSourceDocumentToJustification(justification2, "source1sourceDocument");
                 final Resource justification3 = makeTextJustification(model, "source1", 20, 24, system, 1d);
-                addSourceDocumentToJustification(justification1, "source1sourceDocument");
+                addSourceDocumentToJustification(justification3, "source1sourceDocument");
                 final Resource compound = markCompoundJustification(model,
                         ImmutableSet.of(relationEdge),
                         ImmutableSet.of(justification1, justification2, justification3),
@@ -1877,6 +1877,9 @@ public class ExamplesAndValidationTest {
                 ExamplesAndValidationTest.this.setup();
                 justification = makeTextJustification(model, "NYT_ENG_20181231",
                         42, 143, system, 0.973);
+                addSourceDocumentToJustification(justification, "NYT_PARENT_ENG_20181231_03");
+
+
                 entity = makeEntity(model, getEntityUri(), system);
                 entityCluster = makeClusterWithPrototype(model, getClusterUri(), entity, "handle", system);
                 markJustification(addType(entity, SeedlingOntology.Person), justification);


### PR DESCRIPTION
- Created NIST restriction to enforce all justifications include a source and sourceDocument
- Created valid and invalid test cases to validate the new aforementioned NIST restriction
- Updated all other NISTExamples and Hypothesis test cases that were impacted by the required source and sourceDocument data in the justifications. 