### PR TITLE
Aida 711: Add output options to validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To run the validator from the command line, run `target/appassembler/bin/validat
 with a series of command-line arguments (in any order) honoring the following usage:  <br>
 Usage:  <br>
 `validateAIF { --ldc | --program | --ont FILE ...} [--nist] [--nist-ta3] [-o] [-h | --help] {-f FILE ... | -d DIRNAME}`  <br>
+
 | Switch | Description |
 | ----------- | ----------- |
 |`--ldc`    | validate against the LDC ontology |

--- a/README.md
+++ b/README.md
@@ -73,16 +73,19 @@ validate N files or all files in a specified directory.
 To run the validator from the command line, run `target/appassembler/bin/validateAIF`
 with a series of command-line arguments (in any order) honoring the following usage:  <br>
 Usage:  <br>
-`validateAIF { --ldc | --program | --ont FILE ...} [--nist] [--nist-ta3] [-h | --help] {-f FILE ... | -d DIRNAME}`  <br>
-Options:  <br>
-`--ldc` validate against the LDC ontology  <br>
-`--program` validate against the program ontology  <br>
-`--ont FILE ...` validate against the OWL-formatted ontolog(ies) at the specified filename(s)  <br>
-`--nist` validate against the NIST restrictions  <br>
-`--nist-ta3` validate against the NIST hypothesis restrictions (implies --nist) <br>
-`-h, --help` This help and usage text  <br>
-`-f FILE ...` validate the specified file(s) with a .ttl suffix  <br>
-`-d DIRNAME` validate all .ttl files in the specified directory  <br>
+`validateAIF { --ldc | --program | --ont FILE ...} [--nist] [--nist-ta3] [-o] [-h | --help] {-f FILE ... | -d DIRNAME}`  <br>
+| Switch | Description |
+| ----------- | ----------- |
+|`--ldc`    | validate against the LDC ontology |
+|`--program`| validate against the program ontology |
+|`--ont FILE ...` | validate against the OWL-formatted ontolog(ies) at the specified filename(s) |
+|`--nist` | validate against the NIST restrictions |
+|`--nist-ta3` | validate against the NIST hypothesis restrictions (implies `--nist`) |
+|`-o` | Save validation report model to a file.  `KB.ttl` would result in `KB-report.txt`. Output defaults to stderr. |
+|`-h, --help` | This help and usage text |
+|`-f FILE ...` | validate the specified file(s) with a `.ttl` suffix |
+|`-d DIRNAME` | validate all `.ttl` files in the specified directory |
+
 Either a file (-f) or a directory (-d) must be specified (but not both).  <br>
 Exactly one of --ldc, --program, or --ont must be specified.  <br>
 Ontology files can be found in `src/main/resources/com/ncc/aif/ontologies`:

--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -390,6 +390,11 @@ public final class ValidateAIF {
         } else if (restriction == Restriction.NIST_HYPOTHESIS) {
             logger.info("-> Validating against NIST Hypothesis SHACL.");
         }
+        if (flags.contains(ArgumentFlags.FILE_OUTPUT)) {
+            logger.info("-> Validation report for invalid KBs will be saved to <kbname>-report.txt.");
+        } else {
+            logger.info("-> Validation report for invalid KBs will be printed to stderr.");
+        }
         logger.info("*** Beginning validation of " + filesToValidate.size() + " file(s). ***");
 
         // Validate all files, noting I/O and other errors, but continue to validate even if one fails.
@@ -425,7 +430,8 @@ public final class ValidateAIF {
     // Dump the validation report model either to stderr or a file
     private static void dumpReport(Resource validationReport, File fileToValidate, boolean fileOutput) {
         if (!fileOutput) {
-            validationReport.getModel().write(System.err, FileUtils.langTurtle);
+            logger.info("---> Validation report:");
+            RDFDataMgr.write(System.err, validationReport.getModel(), RDFFormat.TURTLE_PRETTY);
             return;
         }
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -21,8 +21,6 @@ import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -2010,12 +2008,7 @@ public class ExamplesAndValidationTest {
      * @param expected  true if validation is expected to pass, false o/w
      */
     private void assertAndDump(Model model, String testName, ValidateAIF validator, boolean expected) {
-        // capture System.err. Required as validator automatically writes error reports to System.err
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream oldErr = System.err;
-        System.setErr(new PrintStream(baos));
         boolean valid = validator.validateKB(model);
-        System.setErr(oldErr);
 
         // print model if result unexpected or if forcing (for examples)
         // Swap comments following 2 lines if FORCE_DUMP should ALWAYS dump output
@@ -2030,7 +2023,7 @@ public class ExamplesAndValidationTest {
             // only print output if there is any
             if (!valid) {
                 System.out.println("\nFailure:");
-                System.out.println(baos);
+                RDFDataMgr.write(System.out, validator.getValidationReport().getModel(), RDFFormat.TURTLE_PRETTY);
             }
             fail("Validation was expected to " + (expected ? "pass" : "fail") + " but did not");
         }

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -2013,7 +2013,8 @@ public class ExamplesAndValidationTest {
      * @param expected  true if validation is expected to pass, false o/w
      */
     private void assertAndDump(Model model, String testName, ValidateAIF validator, boolean expected) {
-        boolean valid = validator.validateKB(model);
+        final Resource report = validator.validateKBAndReturnReport(model);
+        final boolean valid = ValidateAIF.isValidReport(report);
 
         // print model if result unexpected or if forcing (for examples)
         // Swap comments following 2 lines if FORCE_DUMP should ALWAYS dump output
@@ -2028,7 +2029,7 @@ public class ExamplesAndValidationTest {
             // only print output if there is any
             if (!valid) {
                 System.out.println("\nFailure:");
-                RDFDataMgr.write(System.out, validator.getValidationReport().getModel(), RDFFormat.TURTLE_PRETTY);
+                RDFDataMgr.write(System.out, report.getModel(), RDFFormat.TURTLE_PRETTY);
             }
             fail("Validation was expected to " + (expected ? "pass" : "fail") + " but did not");
         }

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -18,7 +18,7 @@ import java.nio.file.*;
 import java.util.*;
 
 import static com.ncc.aif.AIFUtils.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test to see how large we can scale AIF with the LDC ontology (LO).  AIF uses a Jena-based model,
@@ -436,9 +436,11 @@ public class ScalingTest {
             RDFDataMgr.write(Files.newOutputStream(Paths.get(filename)), model, RDFFormat.TURTLE_PRETTY);
             if (performValidation) {
                 System.out.println("\nDoing validation.  Validation errors (if any) follow:");
-                final boolean valid = ldcValidator.validateKB(model);
-                RDFDataMgr.write(System.err, ldcValidator.getValidationReport().getModel(), RDFFormat.TURTLE_PRETTY);
-                assertTrue(valid);
+                final Resource report = ldcValidator.validateKBAndReturnReport(model);
+                if (!ValidateAIF.isValidReport(report)) {
+                    RDFDataMgr.write(System.err, report.getModel(), RDFFormat.TURTLE_PRETTY);
+                    fail("Generated model was invalid.");
+                }
             }
         } catch (Exception e) {
             System.err.println("Unable to write to file " + filename + " " + e.getMessage());

--- a/src/test/java/com/ncc/aif/ScalingTest.java
+++ b/src/test/java/com/ncc/aif/ScalingTest.java
@@ -436,7 +436,9 @@ public class ScalingTest {
             RDFDataMgr.write(Files.newOutputStream(Paths.get(filename)), model, RDFFormat.TURTLE_PRETTY);
             if (performValidation) {
                 System.out.println("\nDoing validation.  Validation errors (if any) follow:");
-                assertTrue(ldcValidator.validateKB(model));
+                final boolean valid = ldcValidator.validateKB(model);
+                RDFDataMgr.write(System.err, ldcValidator.getValidationReport().getModel(), RDFFormat.TURTLE_PRETTY);
+                assertTrue(valid);
             }
         } catch (Exception e) {
             System.err.println("Unable to write to file " + filename + " " + e.getMessage());


### PR DESCRIPTION
Validator accepts a `-o` switch to create an output file for each file that failed validation (e.g., `foobar.ttl` results in `foobar-results.txt`).  Validator no longer dumps report by default, but it makes the validation report model available to the client.  Updated `README` and `ExamplesAndValidationTests.java`.  Will need to update [AIF Validator page](https://nextcentury.atlassian.net/wiki/spaces/AIDAC/pages/505053485/AIF+Validator) after merge.

To test, use the validator with and without `-o` on files (`-f`) and directories (`-d`).