### PR TITLE
Aida 757

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -248,7 +248,7 @@ aida:InformativeJustificationMembersUniqueParentDoc
       	    {
       	        SELECT $this (COUNT(DISTINCT ?parentDoc) as ?pdCount) (COUNT(DISTINCT ?mentions) as ?mCount)
       	        WHERE {
-      	            ?statement aida:informativeJustification ?mentions .
+      	            $this aida:informativeJustification ?mentions .
       	            ?mentions aida:sourceDocument ?parentDoc
       	        }
       	        GROUP BY $this
@@ -260,7 +260,7 @@ aida:InformativeJustificationMembersUniqueParentDoc
 
 aida:InformativeJustificationMembersShape
     a sh:NodeShape ;
-    sh:targetClass aida:SameAsCluster, aida:Entity, aida:Event, aida:Relation;
+    sh:targetSubjectsOf aida:informativeJustification ;
     sh:sparql aida:InformativeJustificationMembersUniqueParentDoc .
 
 

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -231,4 +231,36 @@ aida:JustificationSourceDocumentShape
 # Each entity/filler name string is limited to 256 UTF-8 characters
 #------------------------
 aida:NamePropertyShape
-  sh:maxLength 256;
+  sh:maxLength 256 .
+
+#########################
+# Each Cluster, Entity, Event, or Relation can specify up to one informative mention per document as long as each
+# informative mention points to a different sourceDocument
+#------------------------
+aida:InformativeJustificationMembersUniqueParentDoc
+    a sh:SPARQLConstraint ;
+    sh:message "Each Cluster, Entity, Event, or Relation can specify up to one informative mention per document as long as each informative mention points to a different sourceDocument" ;
+    sh:select """
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
+        SELECT $this ?pdCount
+        WHERE {
+      	    {
+      	        SELECT $this (COUNT(DISTINCT ?parentDoc) as ?pdCount) (COUNT(DISTINCT ?mentions) as ?mCount)
+      	        WHERE {
+      	            ?statement aida:informativeJustification ?mentions .
+      	            ?mentions aida:sourceDocument ?parentDoc
+      	        }
+      	        GROUP BY $this
+      	    }
+      	    FILTER(?pdCount < ?mCount)
+        }
+    """
+    .
+
+aida:InformativeJustificationMembersShape
+    a sh:NodeShape ;
+    sh:targetClass aida:SameAsCluster, aida:Entity, aida:Event, aida:Relation;
+    sh:sparql aida:InformativeJustificationMembersUniqueParentDoc .
+
+

--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -243,18 +243,13 @@ aida:InformativeJustificationMembersUniqueParentDoc
     sh:select """
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX aida:  <https://tac.nist.gov/tracks/SM-KBP/2018/ontologies/InterchangeOntology#>
-        SELECT $this ?pdCount
-        WHERE {
-      	    {
-      	        SELECT $this (COUNT(DISTINCT ?parentDoc) as ?pdCount) (COUNT(DISTINCT ?mentions) as ?mCount)
-      	        WHERE {
-      	            $this aida:informativeJustification ?mentions .
-      	            ?mentions aida:sourceDocument ?parentDoc
-      	        }
-      	        GROUP BY $this
-      	    }
-      	    FILTER(?pdCount < ?mCount)
-        }
+      	SELECT $this
+      	WHERE {
+      	    $this aida:informativeJustification ?mentions .
+      	    ?mentions aida:sourceDocument ?parentDoc
+      	}
+      	GROUP BY $this
+      	HAVING (COUNT(DISTINCT ?parentDoc) < COUNT(DISTINCT ?mentions))
     """
     .
 

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -784,6 +784,67 @@ public class ExamplesAndValidationTest {
             testValid("create an entity and cluster with informative mention");
         }
 
+        @Test
+        void createInformativeJustificationExamples1() {
+            // Two people, probably the same person
+            final String vladName = "Vladimir Putin";
+            final Resource vladimirPutin = makeEntity(model, getUri("E780885.00311"), system);
+            markName(vladimirPutin, vladName);
+
+            final Resource typeAssertion = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
+            final Resource justification = markTextJustification(model, typeAssertion, "HC00002Z0", 0, 10, system, 1d);
+            addSourceDocumentToJustification(justification, "HC00002Z0_PARENTDOC");
+            markInformativeJustification(vladimirPutin, justification);
+
+            testInvalid("create an entity and cluster with informative mention");
+        }
+
+        @Test
+        void createInformativeJustificationExamples2() {
+            // Two people, probably the same person
+            final String vladName = "Vladimir Putin";
+            final Resource vladimirPutin = makeEntity(model, getUri("E780885.00311"), system);
+            markName(vladimirPutin, vladName);
+
+            final Resource typeAssertion = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
+            final Resource justification = markTextJustification(model, typeAssertion, "HC00002Z0", 0, 10, system, 1d);
+            addSourceDocumentToJustification(justification, "MC038302Z0_PARENTDOC");
+
+            final Resource typeAssertion2 = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
+            final Resource justification2 = markTextJustification(model, typeAssertion2, "MC038302Z0", 0, 10, system, 1d);
+            addSourceDocumentToJustification(justification2, "MC038302Z0_PARENTDOC");
+
+            markInformativeJustification(vladimirPutin, justification);
+            markInformativeJustification(vladimirPutin, justification2);
+
+            testInvalid("create an entity and cluster with informative mention");
+        }
+
+
+        @Test
+        void createInformativeJustificationExamples3() {
+            // Two people, probably the same person
+            final String vladName = "Vladimir Putin";
+            final Resource vladimirPutin = makeEntity(model, getUri("E780885.00311"), system);
+            markName(vladimirPutin, vladName);
+
+            final Resource typeAssertion = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
+            final Resource justification = markTextJustification(model, typeAssertion, "HC00002Z0", 0, 10, system, 1d);
+            addSourceDocumentToJustification(justification, "HC00002Z0_PARENTDOC");
+
+            final Resource typeAssertion2 = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
+            final Resource justification2 = markTextJustification(model, typeAssertion2, "MC038302Z0", 0, 10, system, 1d);
+            addSourceDocumentToJustification(justification2, "MC038302Z0_PARENTDOC");
+
+            markInformativeJustification(vladimirPutin, justification);
+            markInformativeJustification(vladimirPutin, justification2);
+
+            testInvalid("create an entity and cluster with informative mention");
+        }
+
+
+
+
         /**
          * Shows how to create a relation with uncertain endpoints using the version of coreference expected for
          * output NIST will execute SPARQL queries on.

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1666,38 +1666,114 @@ public class ExamplesAndValidationTest {
         class InformativeJustification {
 
             @Test
+            void invalidArgumentInformativeJustification() {
+
+                // create relation argument and mark it as an informative justification
+                final Resource relationEdge = markAsArgument(model, relation,
+                        SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d);
+                markInformativeJustification(relationEdge, typeAssertionJustification);
+
+                testInvalid("NIST.invalid: (informative justification specified on argument) Each Cluster, " +
+                        "Entity, Event, or Relation can specify up to one informative mention per document");
+            }
+
+            @Test
+            void invalidInformativeJustificationDuplicateParentDoc() {
+
+                final Resource duplicateParentDocJustification = makeTextJustification(model, "ZM39482011",
+                        42, 143, system, 0.973);
+                addSourceDocumentToJustification(duplicateParentDocJustification,"20181231");
+
+                markInformativeJustification(entity, typeAssertionJustification);
+                markInformativeJustification(entity, duplicateParentDocJustification);
+
+                testInvalid("NIST.invalid: (informative justifications have same parent document) Each Cluster, " +
+                        "Entity, Event, or Relation can specify up to one informative mention per document as long " +
+                        "as each informative mention points to a different sourceDocument");
+
+            }
+
+            @Test
             void validEntityInformativeJustification() {
-                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+
+                markInformativeJustification(entity, typeAssertionJustification);
+                testValid("NIST.valid: (entity) Each Cluster, Entity, Event, or Relation can specify up to one " +
+                        "informative mention per document");
             }
 
             @Test
             void validEventInformativeJustification() {
-                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+                markInformativeJustification(event, typeAssertionJustification);
+                testValid("NIST.valid: (event) Each Cluster, Entity, Event, or Relation can specify up to one " +
+                        "informative mention per document");
 
             }
 
             @Test
             void validRelationInformativeJustification() {
-                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+                markInformativeJustification(relation, typeAssertionJustification);
+                testValid("NIST.valid: (relation) Each Cluster, Entity, Event, or Relation can specify up to one " +
+                        "informative mention per document");
             }
 
             @Test
             void validClusterInformativeJustification() {
-                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+                markInformativeJustification(entityCluster, typeAssertionJustification);
+                testValid("NIST.valid: (cluster) Each Cluster, Entity, Event, or Relation can specify up to one " +
+                        "informative mention per document");
             }
 
             @Test
-            void invalidArgumentInformativeJustification() {
-                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+            void validRelationWithMultipleInformativeJustifications() {
+
+                final Resource secondJustification = makeTextJustification(model, "EJ39281",
+                        42, 143, system, 0.973);
+                addSourceDocumentToJustification(secondJustification,"3822029");
+
+                final Resource thirdJustification = makeTextJustification(model, "CL33838",
+                        42, 143, system, 0.973);
+                addSourceDocumentToJustification(thirdJustification,"3948290");
+
+                //add three informative justifications to same relation KE
+                markInformativeJustification(relation, typeAssertionJustification);
+                markInformativeJustification(relation, secondJustification);
+                markInformativeJustification(relation, thirdJustification);
+
+                testValid("NIST.valid: (multiple informative justifications on relation) Each Cluster," +
+                        "Entity, Event, or Relation can specify up to one informative mention per document as long " +
+                        "as each informative mention points to a different sourceDocument");
+
             }
 
+            @Test
+            void validEntityClusterSeparateInformativeJustificationsWithSameParentDoc() {
+
+                final Resource duplicateParentDocJustification = makeTextJustification(model, "ZM39482011",
+                        42, 143, system, 0.973);
+                addSourceDocumentToJustification(duplicateParentDocJustification,"20181231");
+
+                final Resource secondEntityJustification = makeTextJustification(model, "EJ39281",
+                        42, 143, system, 0.973);
+                addSourceDocumentToJustification(secondEntityJustification,"3822029");
+
+                final Resource secondClusterJustification = makeTextJustification(model, "CL33838",
+                        42, 143, system, 0.973);
+                addSourceDocumentToJustification(secondClusterJustification,"3298329");
+
+                //add informative justification in separate KE's with same parent doc
+                markInformativeJustification(entity, typeAssertionJustification);
+                markInformativeJustification(entity, secondEntityJustification);
+
+                //add more than on informative justification to the KE's
+                markInformativeJustification(entityCluster, duplicateParentDocJustification);
+                markInformativeJustification(entityCluster, secondClusterJustification);
+
+                testValid("NIST.valid: (Two KE's with informative justifications with same parent doc) Each " +
+                        "Cluster, Entity, Event, or Relation can specify up to one informative mention per document " +
+                        "as long as each informative mention points to a different sourceDocument");
+
+            }
         }
-
-        @Nested
-        class InformativeJustificationParentDocs {
-
-        }
-
     }
 
     /**

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -783,65 +783,7 @@ public class ExamplesAndValidationTest {
 
             testValid("create an entity and cluster with informative mention");
         }
-
-        @Test
-        void createInformativeJustificationExamples1() {
-            // Two people, probably the same person
-            final String vladName = "Vladimir Putin";
-            final Resource vladimirPutin = makeEntity(model, getUri("E780885.00311"), system);
-            markName(vladimirPutin, vladName);
-
-            final Resource typeAssertion = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
-            final Resource justification = markTextJustification(model, typeAssertion, "HC00002Z0", 0, 10, system, 1d);
-            addSourceDocumentToJustification(justification, "HC00002Z0_PARENTDOC");
-            markInformativeJustification(vladimirPutin, justification);
-
-            testInvalid("create an entity and cluster with informative mention");
-        }
-
-        @Test
-        void createInformativeJustificationExamples2() {
-            // Two people, probably the same person
-            final String vladName = "Vladimir Putin";
-            final Resource vladimirPutin = makeEntity(model, getUri("E780885.00311"), system);
-            markName(vladimirPutin, vladName);
-
-            final Resource typeAssertion = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
-            final Resource justification = markTextJustification(model, typeAssertion, "HC00002Z0", 0, 10, system, 1d);
-            addSourceDocumentToJustification(justification, "MC038302Z0_PARENTDOC");
-
-            final Resource typeAssertion2 = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
-            final Resource justification2 = markTextJustification(model, typeAssertion2, "MC038302Z0", 0, 10, system, 1d);
-            addSourceDocumentToJustification(justification2, "MC038302Z0_PARENTDOC");
-
-            markInformativeJustification(vladimirPutin, justification);
-            markInformativeJustification(vladimirPutin, justification2);
-
-            testInvalid("create an entity and cluster with informative mention");
-        }
-
-
-        @Test
-        void createInformativeJustificationExamples3() {
-            // Two people, probably the same person
-            final String vladName = "Vladimir Putin";
-            final Resource vladimirPutin = makeEntity(model, getUri("E780885.00311"), system);
-            markName(vladimirPutin, vladName);
-
-            final Resource typeAssertion = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
-            final Resource justification = markTextJustification(model, typeAssertion, "HC00002Z0", 0, 10, system, 1d);
-            addSourceDocumentToJustification(justification, "HC00002Z0_PARENTDOC");
-
-            final Resource typeAssertion2 = markType(model, getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
-            final Resource justification2 = markTextJustification(model, typeAssertion2, "MC038302Z0", 0, 10, system, 1d);
-            addSourceDocumentToJustification(justification2, "MC038302Z0_PARENTDOC");
-
-            markInformativeJustification(vladimirPutin, justification);
-            markInformativeJustification(vladimirPutin, justification2);
-
-            testInvalid("create an entity and cluster with informative mention");
-        }
-
+        
         /**
          * Shows how to create a relation with uncertain endpoints using the version of coreference expected for
          * output NIST will execute SPARQL queries on.

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -783,7 +783,7 @@ public class ExamplesAndValidationTest {
 
             testValid("create an entity and cluster with informative mention");
         }
-        
+
         /**
          * Shows how to create a relation with uncertain endpoints using the version of coreference expected for
          * output NIST will execute SPARQL queries on.
@@ -1616,7 +1616,8 @@ public class ExamplesAndValidationTest {
                 markInformativeJustification(relationEdge, typeAssertionJustification);
 
                 testInvalid("NIST.invalid: (informative justification specified on argument) Each Cluster, " +
-                        "Entity, Event, or Relation can specify up to one informative mention per document");
+                        "Entity, Event, or Relation can specify up to one informative mention per document as each" +
+                        " informative mention points to a different sourceDocument");
             }
 
             @Test
@@ -1640,14 +1641,16 @@ public class ExamplesAndValidationTest {
 
                 markInformativeJustification(entity, typeAssertionJustification);
                 testValid("NIST.valid: (entity) Each Cluster, Entity, Event, or Relation can specify up to one " +
-                        "informative mention per document");
+                        "informative mention per document as each informative mention points to a " +
+                        "different sourceDocument");
             }
 
             @Test
             void validEventInformativeJustification() {
                 markInformativeJustification(event, typeAssertionJustification);
                 testValid("NIST.valid: (event) Each Cluster, Entity, Event, or Relation can specify up to one " +
-                        "informative mention per document");
+                        "informative mention per document as each informative mention points to a different " +
+                        "sourceDocument");
 
             }
 
@@ -1655,14 +1658,16 @@ public class ExamplesAndValidationTest {
             void validRelationInformativeJustification() {
                 markInformativeJustification(relation, typeAssertionJustification);
                 testValid("NIST.valid: (relation) Each Cluster, Entity, Event, or Relation can specify up to one " +
-                        "informative mention per document");
+                        "informative mention per document as each informative mention points to a different " +
+                        "sourceDocument");
             }
 
             @Test
             void validClusterInformativeJustification() {
                 markInformativeJustification(entityCluster, typeAssertionJustification);
                 testValid("NIST.valid: (cluster) Each Cluster, Entity, Event, or Relation can specify up to one " +
-                        "informative mention per document");
+                        "informative mention per document as each informative mention points to a different " +
+                        "sourceDocument");
             }
 
             @Test

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1607,18 +1607,6 @@ public class ExamplesAndValidationTest {
         @Nested
         class InformativeJustification {
 
-            @Test
-            void invalidArgumentInformativeJustification() {
-
-                // create relation argument and mark it as an informative justification
-                final Resource relationEdge = markAsArgument(model, relation,
-                        SeedlingOntology.GeneralAffiliation_APORA_Affiliate, entity, system, 1d);
-                markInformativeJustification(relationEdge, typeAssertionJustification);
-
-                testInvalid("NIST.invalid: (informative justification specified on argument) Each Cluster, " +
-                        "Entity, Event, or Relation can specify up to one informative mention per document as each" +
-                        " informative mention points to a different sourceDocument");
-            }
 
             @Test
             void invalidInformativeJustificationDuplicateParentDoc() {
@@ -1633,7 +1621,6 @@ public class ExamplesAndValidationTest {
                 testInvalid("NIST.invalid: (informative justifications have same parent document) Each Cluster, " +
                         "Entity, Event, or Relation can specify up to one informative mention per document as long " +
                         "as each informative mention points to a different sourceDocument");
-
             }
 
             @Test

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -842,9 +842,6 @@ public class ExamplesAndValidationTest {
             testInvalid("create an entity and cluster with informative mention");
         }
 
-
-
-
         /**
          * Shows how to create a relation with uncertain endpoints using the version of coreference expected for
          * output NIST will execute SPARQL queries on.
@@ -1663,6 +1660,42 @@ public class ExamplesAndValidationTest {
                 addSourceDocumentToJustification(newJustification, "HC00002ZO");
                 testValid("NIST.valid: justifications require a source document and a source");
             }
+        }
+
+        @Nested
+        class InformativeJustification {
+
+            @Test
+            void validEntityInformativeJustification() {
+                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+            }
+
+            @Test
+            void validEventInformativeJustification() {
+                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+
+            }
+
+            @Test
+            void validRelationInformativeJustification() {
+                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+            }
+
+            @Test
+            void validClusterInformativeJustification() {
+                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+            }
+
+            @Test
+            void invalidArgumentInformativeJustification() {
+                testValid("NIST.valid: Each entity name string is limited to 256 UTF-8 characters");
+            }
+
+        }
+
+        @Nested
+        class InformativeJustificationParentDocs {
+
         }
 
     }


### PR DESCRIPTION
- Created NIST restriction to enforce that all informative mentions on a KE points to a different sourceDocument
- Created valid and invalid test cases to validate the new aforementioned NIST restriction
- Created valid and invalid test cases to valid that informative mentions can only live on Clusters, Entities, Relations, and Events. 