### PR TITLE
fix platform specific character encoding build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,11 @@
     <artifactId>aida-interchange</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-
     <properties>
         <kotlin.version>1.3.21</kotlin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
current build produces the following warnings:

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
```

fixed by this commit