### PR TITLE
AIDA-802: Update jar versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,16 +8,18 @@
     <artifactId>aida-interchange</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-
     <properties>
         <kotlin.version>1.3.21</kotlin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>io.github.microutils</groupId>
@@ -33,7 +35,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
+            <version>27.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -58,21 +60,20 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
-
 
         <!-- for SHACL validation -->
         <dependency>
@@ -123,12 +124,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.1</version>
                 <configuration>
                     <compilerId>javac-with-errorprone</compilerId>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <!-- maven-compiler-plugin defaults to targeting Java 5, but our javac
-                         only supports >=6 -->
+                    <!-- maven-compiler-plugin defaults to targeting Java 1.6, but AIDA
+                         targets 1.8. -->
                     <source>8</source>
                     <target>8</target>
                     <!-- Prevents an endPosTable exception during compilation


### PR DESCRIPTION
- Updated various jar versions to latest.
- Fixed Kotlin warnings for [PR-177](https://github.com/NextCenturyCorporation/AIDA-Interchange-Format/pull/177).
- Did *not* update Jena because it breaks our TDB tests, and appears to have something to do with mixing Jena versions (3.11 in AIF and 3.7 in TopBraid shacl jar)
- Did *not* update JUnit/surefire because we get warnings for the `junit-platform-surefire-provider` being deprecated in JUnit platform 1.3.  "Please use Maven Surefire’s native support instead."  Maybe someday...