### PR TITLE
AIDA-808:  Fix LDCTimeShape bug

### DIFF
--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -837,7 +837,7 @@ aida:LDCTimeShape
         sh:class aida:LDCTimeComponent
     ] ;
 
-    sh:property sh:JustificationPropertyShape ;
+    sh:property aida:JustificationPropertyShape ;
 
     # may provide an optional source system
     sh:property aida:SystemPropertyShape ;

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1048,12 +1048,16 @@ public class ExamplesAndValidationTest {
             LDCTimeComponent unknown = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.UNKNOWN, null, null, null);
             LDCTimeComponent endBefore = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2016", null, null);
             markLDCTime(model, eventStartPosition, unknown, endBefore, system);
+            Resource time = markLDCTime(model, eventStartPosition, unknown, endBefore, system);
+            markJustification(time, utils.makeValidJustification());
 
             // Create an attack event with an unknown start date, but definite end date
             final Resource eventAttackUnknown = utils.makeValidAIFEvent(SeedlingOntology.Conflict_Attack);
             LDCTimeComponent start = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2014", "--02", null);
             LDCTimeComponent end = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.ON, "2014", "--02", "---21");
             markLDCTime(model, eventAttackUnknown, start, end, system);
+            time = markLDCTime(model, eventAttackUnknown, start, end, system);
+            markJustification(time, utils.makeValidJustification());
 
             utils.testValid("create an event with LDCTime");
         }


### PR DESCRIPTION
- Fixed AIF SHACL.
- Added justification to `createEventWithLDCTime()` test.

This PR is just for master.  Incorporation into the v1.0.x branch will occur in a separate [Jira task](https://nextcentury.atlassian.net/browse/AIDA-817) with its own associated PR.