### PR TITLE
AIDA-827: Add clusters and cluster memberships to hypotheses.

### DIFF
--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -6,7 +6,6 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharSource;
 import com.google.common.io.Resources;
-import org.apache.jena.ontology.OntModel;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
@@ -152,9 +151,7 @@ public final class ValidateAIF {
             throw new IllegalArgumentException("Must validate against at least one domain ontology.");
         }
 
-        final OntModel model = ModelFactory.createOntologyModel();
-        model.addLoadedImport(INTERCHANGE_URI);
-        model.addLoadedImport(AIDA_DOMAIN_COMMON_URI);
+        final Model model = ModelFactory.createDefaultModel();
 
         // Data will always be interpreted in the context of these two ontology files.
         final ImmutableSet<CharSource> aidaModels = ImmutableSet.of(
@@ -466,7 +463,7 @@ public final class ValidateAIF {
             Date date = Calendar.getInstance().getTime();
             logger.info("-> Validating " + fileToValidate + " at " + format.format(date) +
                     " (" + ++fileNum + " of " + filesToValidate.size() + ").");
-            final OntModel dataToBeValidated = ModelFactory.createOntologyModel();
+            final Model dataToBeValidated = ModelFactory.createDefaultModel();
             boolean notSkipped = ((restriction != Restriction.NIST_HYPOTHESIS) || checkHypothesisSize(fileToValidate))
                     && loadFile(dataToBeValidated, fileToValidate);
             if (notSkipped) {
@@ -544,9 +541,7 @@ public final class ValidateAIF {
     }
 
     // Load the model, or fail trying.  Returns true if it's loaded, otherwise false.
-    private static boolean loadFile(OntModel dataToBeValidated, File fileToValidate) {
-        dataToBeValidated.addLoadedImport(INTERCHANGE_URI);
-        dataToBeValidated.addLoadedImport(AIDA_DOMAIN_COMMON_URI);
+    private static boolean loadFile(Model dataToBeValidated, File fileToValidate) {
         try {
             loadModel(dataToBeValidated, com.google.common.io.Files.asCharSource(fileToValidate, Charsets.UTF_8));
         } catch (RuntimeException rte) {

--- a/src/main/resources/com/ncc/aif/aida_ontology.shacl
+++ b/src/main/resources/com/ncc/aif/aida_ontology.shacl
@@ -1164,6 +1164,7 @@ aida:ContentGraphShape
             [sh:class aida:Relation]
             [sh:class aida:SentimentAssertion]
             [sh:class aida:ClusterMembership]
+            [sh:class aida:SameAsCluster]
             [sh:class rdf:Statement] ) ;
         sh:message "Content graph cannot contain this type of node"
     ] ;

--- a/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_hypothesis_aif.shacl
@@ -166,7 +166,7 @@ aida:KEsMustBeReferenced
 
 aida:AllKEsReferencedShape
     a sh:NodeShape ;
-    sh:targetClass aida:Entity, aida:Event, aida:Relation ;
+    sh:targetClass aida:Entity, aida:Event, aida:Relation, aida:ClusterMembership, aida:SameAsCluster;
     sh:target [
         a sh:SPARQLTarget ;
         sh:select """

--- a/src/test/java/com/ncc/aif/TestUtils.java
+++ b/src/test/java/com/ncc/aif/TestUtils.java
@@ -262,7 +262,16 @@ class TestUtils {
     Resource makeValidAIFHypothesis(String uri, Resource... resources) {
         Set<Resource> set = new HashSet<>();
         Collections.addAll(set, resources);
-        return makeHypothesis(model, uri == null ? getHypothesisUri() : uri, set, system);
+        return makeValidAIFHypothesis(uri, set);
+    }
+
+    /**
+     * Makes and returns a valid hypothesis object involving the specified resource(s) using the specified URI.
+     *
+     * @param resources A {@link Set} of entities, relations, and arguments that contribute to the hypothesis
+     */
+    Resource makeValidAIFHypothesis(String uri, Set<Resource> resources) {
+        return makeHypothesis(model, uri == null ? getHypothesisUri() : uri, resources, system);
     }
 
     /**


### PR DESCRIPTION
Use default Jena models instead of OntModel.
Add SameAsCluster to subgraphContains.
Add ClusterMembership and SameAsCluster to AllKEsReferencedShape.
Modify NistTA3ExamplesAndValidationTest to add clusters and memberships.
Modify NistTA3TestUtils to add clusters and memberships by default.