### PR TITLE
AIDA-811: Fix NIST restriction 4.3.6.3

### DIFF
--- a/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -60,11 +60,7 @@ aida:RestrictCompoundJustificationPropertyShape
    sh:not [sh:class aida:CompoundJustification] ;
    sh:message "CompoundJustification must be used only for justifications of argument assertions" .
 
-aida:EventShape
-    # may not provide compound justification
-    sh:property aida:RestrictCompoundJustificationPropertyShape .
-
-aida:RelationShape
+aida:EventRelationShape
     # may not provide compound justification
     sh:property aida:RestrictCompoundJustificationPropertyShape .
 


### PR DESCRIPTION
Moved `aida:RestrictCompoundJustificationPropertyShape` to the combined `aida:EventRelationShape`.
Breaking up the test will be handled in [AIDA-813](https://nextcentury.atlassian.net/browse/AIDA-813) and/or [AIDA-796](https://nextcentury.atlassian.net/browse/AIDA-796).