### PR TITLE
Aida 735: Test using the TDB model for large TA2 KBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains resources to support the AIDA Interchange Format (AIF).
      translation of these examples is in `python/tests/Examples.py`.  If you run either set of
      examples, the corresponding Turtle output will be dumped.
 
-*    the `validateAIF` command line utility that can be used to validate AIF .ttl files. See below for details. 
+*    the `validateAIF` command line utility that can be used to validate AIF `.ttl` files. See below for details. 
 
 We recommend using Turtle format for AIF when working with single document files (for
 readability) but N-Triples for working with large KBs (for speed).
@@ -70,6 +70,7 @@ Usage:  <br>
 |`--nist-ta3` | validate against the NIST hypothesis restrictions (implies `--nist`) |
 |`--abort[=num]` | Abort validation after `[num]` SHACL violations (num > 2), or three violations if `[num]` is omitted. |
 |`--pm` | Enable progress monitor that shows ongoing validation progress |
+|`--disk` | Use disk-based model for validating very large files |
 |`-o` | Save validation report model to a file.  `KB.ttl` would result in `KB-report.txt`. Output defaults to stderr. |
 |`-t=num` | Specify the number of threads to use during validation. As the threaded validator doesn't currently support adding a progress monitor, this disables the --pm option. |
 |`-d=DIRNAME` | validate all `.ttl` files in the specified directory |

--- a/src/main/java/com/ncc/aif/ValidateAIF.java
+++ b/src/main/java/com/ncc/aif/ValidateAIF.java
@@ -50,7 +50,7 @@ public final class ValidateAIF {
     private static final String AO_EVENTS_RESNAME = ONT_ROOT + "EventOntology";
     private static final String AO_RELATIONS_RESNAME = ONT_ROOT + "RelationOntology";
 
-    public static final String DOMAIN_MODEL_PATH = "target/tdb-output/domainModel";
+    public static final String DOMAIN_MODEL_PATH = System.getProperty("java.io.tmpdir") + "/domainModel";
 
     private static Model shaclModel;
     private static Model nistModel;
@@ -165,6 +165,7 @@ public final class ValidateAIF {
                     Files.walk(directory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
                 }
                 Files.createDirectories(directory);
+                directory.toFile().deleteOnExit(); // not guaranteed
                 final Dataset dataset = TDBFactory.createDataset(directory.toString());
                 model = dataset.getDefaultModel();
             } catch (IOException e) {

--- a/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -231,9 +231,6 @@ public class ValidateAIFCli implements Callable<Integer> {
 
         // Finally, try to create the validator, but fail if required elements can't be loaded/parsed.
         ValidateAIF validator;
-        if (useDiskModel) {
-            ValidateAIF.setDiskBased(true);
-        }
         final String ontologyStr;
         try {
             if (useLDCOntology) {

--- a/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -312,12 +312,13 @@ public class ValidateAIFCli implements Callable<Integer> {
                     " (" + ++fileNum + " of " + filesToValidate.size() + ").");
             Model dataToBeValidated;
             Path directory = null;
+            Dataset dataset = null;
             if (useDiskModel) {
                 try {
                     deleteDir(Paths.get(DATA_MODEL_PATH));
                     directory = Paths.get(DATA_MODEL_PATH, fileToValidate.getName().replace(".ttl", ""));
                     Files.createDirectories(directory);
-                    Dataset dataset = TDBFactory.createDataset(directory.toString());
+                    dataset = TDBFactory.createDataset(directory.toString());
                     dataToBeValidated = dataset.getDefaultModel();
                 }
                 catch (IOException ioe) {
@@ -372,6 +373,9 @@ public class ValidateAIFCli implements Callable<Integer> {
 
             dataToBeValidated.close();
             if (useDiskModel) {
+                if (dataset != null) {
+                    dataset.close();
+                }
                 deleteDir(directory); // Clean up after ourselves
             }
         }

--- a/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -80,7 +80,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     private static final String THREAD_COUNT_STRING = "Thread count";
     private static final int MINIMUM_THREAD_COUNT = 1;
     // Disk-based model
-    private static final String DATA_MODEL_PATH = System.getProperty("java.io.tmpdir") + "/dataModels";
+    private static final String DATA_MODEL_PATH = System.getProperty("java.io.tmpdir") + "/diskbased-models/dataModels";
 
     //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     // Command Line Arguments
@@ -315,8 +315,8 @@ public class ValidateAIFCli implements Callable<Integer> {
             Dataset dataset = null;
             if (useDiskModel) {
                 try {
-                    deleteDir(Paths.get(DATA_MODEL_PATH));
                     dataModelDir = Paths.get(DATA_MODEL_PATH, fileToValidate.getName().replace(".ttl", ""));
+                    deleteDir(dataModelDir);  // Delete the directory if it exists
                     Files.createDirectories(dataModelDir);
                     dataset = TDBFactory.createDataset(dataModelDir.toString());
                     dataToBeValidated = dataset.getDefaultModel();

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.topbraid.shacl.vocabulary.SH;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,6 +46,7 @@ public class ExamplesAndValidationTest {
     private static final String NIST_ROOT = "https://tac.nist.gov/tracks/SM-KBP/";
     private static final String LDC_NS = NIST_ROOT + "2019/LdcAnnotations#";
     private static final String ONTOLOGY_NS = NIST_ROOT + "2018/ontologies/SeedlingOntology#";
+    private static final String DISKBASED_MODEL_PATH = System.getProperty("java.io.tmpdir") + "/diskbased-models/tests";
     private static final CharSource SEEDLING_ONTOLOGY = Resources.asCharSource(
             Resources.getResource("com/ncc/aif/ontologies/SeedlingOntology"),
             StandardCharsets.UTF_8);
@@ -54,6 +56,13 @@ public class ExamplesAndValidationTest {
     static void initTest() {
         // prevent too much logging from obscuring the Turtle examples which will be printed
         ((Logger) org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.INFO);
+        try {
+            if (Files.exists(Paths.get(DISKBASED_MODEL_PATH))) { // Delete the directory if it exists
+                Files.walk(Paths.get(DISKBASED_MODEL_PATH)).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        } catch (IOException ioe) {
+            System.err.println("Unable to delete disk-based model directory: " + ioe.getMessage());
+        }
         utils = new TestUtils(LDC_NS, ValidateAIF.createForDomainOntologySource(SEEDLING_ONTOLOGY), DUMP_ALWAYS, DUMP_TO_FILE);
     }
 
@@ -1184,12 +1193,7 @@ public class ExamplesAndValidationTest {
 
     private ImmutablePair<Model, Dataset> createDiskBasedModel() {
         try {
-            final String DATA_MODEL_PATH = System.getProperty("java.io.tmpdir") + "/diskbased-models";
-            Path directory = Paths.get(DATA_MODEL_PATH);
-            if (Files.exists(directory)) { // Delete the directory if it exists
-                Files.walk(directory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-            }
-            Path dataModelDir = Paths.get(DATA_MODEL_PATH, "model" + ++diskModelCount);
+            Path dataModelDir = Paths.get(DISKBASED_MODEL_PATH, "testmodel" + ++diskModelCount);
             System.out.println("Creating disk based model at " + dataModelDir.toString());
             Files.createDirectories(dataModelDir);
             final Dataset dataset = TDBFactory.createDataset(dataModelDir.toString());

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharSource;
 import com.google.common.io.Resources;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
@@ -20,10 +21,13 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.topbraid.shacl.vocabulary.SH;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Comparator;
 
 import static com.ncc.aif.AIFUtils.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -55,6 +59,7 @@ public class ExamplesAndValidationTest {
 
     private Model model;
     private Resource system;
+    private int diskModelCount = 0;
 
     @BeforeEach
     void setup() {
@@ -993,7 +998,8 @@ public class ExamplesAndValidationTest {
 
         @Test
         void createEntityWithDiskBaseModelAndWriteOut() {
-            final Model model = createDiskBasedModel();
+            final ImmutablePair<Model, Dataset> pair = createDiskBasedModel();
+            final Model model = pair.getLeft();
 
             // every AIF needs an object for the system responsible for creating it
             final Resource system = makeSystemWithURI(model, utils.getTestSystemUri());
@@ -1008,9 +1014,14 @@ public class ExamplesAndValidationTest {
                     "HC000T6IV", 1029, 1033, system, 0.973);
 
             Path filename = writeModelToDisk(model);
+            model.close();
+            pair.getRight().close();
 
-            final Model model2 = readModelFromDisk(filename);
+            final ImmutablePair<Model, Dataset> pair2 = readModelFromDisk(filename);
+            final Model model2 = pair2.getLeft();
             Resource rtest = model2.getResource(putinDocumentEntityUri);
+            model2.close();
+            pair2.getRight().close();
             assertNotNull(rtest, "Entity does not exist");
         }
 
@@ -1159,11 +1170,11 @@ public class ExamplesAndValidationTest {
         return outputPath;
     }
 
-    private Model readModelFromDisk(Path filename) {
+    private ImmutablePair<Model, Dataset> readModelFromDisk(Path filename) {
         try {
-            Model model = createDiskBasedModel();
-            RDFDataMgr.read(model, Files.newInputStream(filename), Lang.TURTLE);
-            return model;
+            ImmutablePair<Model, Dataset> pair = createDiskBasedModel();
+            RDFDataMgr.read(pair.getLeft(), Files.newInputStream(filename), Lang.TURTLE);
+            return pair;
         } catch (Exception e) {
             System.err.println("Unable to write to tempfile " + e.getMessage());
             e.printStackTrace();
@@ -1171,13 +1182,19 @@ public class ExamplesAndValidationTest {
         return null;
     }
 
-    private Model createDiskBasedModel() {
+    private ImmutablePair<Model, Dataset> createDiskBasedModel() {
         try {
-            final Path outputPath = Files.createTempDirectory("diskbased-model-");
-            System.out.println("Creating disk based model at " + outputPath.toString());
-            final Dataset dataset = TDBFactory.createDataset(outputPath.toString());
+            final String DATA_MODEL_PATH = System.getProperty("java.io.tmpdir") + "/diskbased-models";
+            Path directory = Paths.get(DATA_MODEL_PATH);
+            if (Files.exists(directory)) { // Delete the directory if it exists
+                Files.walk(directory).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+            Path dataModelDir = Paths.get(DATA_MODEL_PATH, "model" + ++diskModelCount);
+            System.out.println("Creating disk based model at " + dataModelDir.toString());
+            Files.createDirectories(dataModelDir);
+            final Dataset dataset = TDBFactory.createDataset(dataModelDir.toString());
             final Model model = dataset.getDefaultModel();
-            return addNamespacesToModel(model);
+            return new ImmutablePair<>(addNamespacesToModel(model), dataset);
         } catch (Exception e) {
             System.err.println("Unable to create temp directory: " + e.getMessage());
             e.printStackTrace();


### PR DESCRIPTION
- Added `--disk` option to enable disk-based model
- Attempted to clean up as much as possible from the HD on both Linux and Windows
- Tested in conjunction with `--abort`, `-p`, `--p2`, `--pm`, and `-t`.
- Summary of execution results with and without disk-based model available [on Confluence](https://nextcentury.atlassian.net/wiki/spaces/AIDA/pages/510558318/AIF+Validator+Performance) (look for reference to AIDA-735).