### PR TITLE
Adding m18 submission checker script

### DIFF
--- a/scripts/aida_m18_submission_checker.py
+++ b/scripts/aida_m18_submission_checker.py
@@ -1,0 +1,370 @@
+'''
+This script is designed to parse an archive [.zip, .tgz, .tar.gz] and determine if it is properly structured, and will
+work with Next Century's validator.
+
+To run:
+python3 aida_m18_submission_checker.py <path/to/archive>
+
+Output will be printed to stdout and/or stderr
+'''
+import sys                  #for sys.args
+from sys import exit as exit
+import os                   #for extention access (basename)
+import tarfile, zipfile     #for archive access
+import re                   #for regex
+
+
+'''
+Globals
+'''
+
+#variable to store if we use tar or zip method to access the file
+#-1 = error. cannot continue
+#0 = .tar.gz, or .tgz
+#1 = .zip
+FILETYPE = -1
+
+#task types to validate for
+TASK_TYPES = ["1a", "1b", "2", "3"]
+
+#list of names of items in the archive - to be populated after determining what filetype the archive is
+ARCHIVE_NAMES = []
+
+
+def eprint(*args, **kwargs):
+    """simple function to print to stderr
+
+    :param args: data to print
+    :param kwargs: keywords to pass in print args
+    """
+    #*****************
+    # REQUIRES PYTHON 3+
+    #*****************
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def do_TA1a_check():
+    """
+    Check the archive
+    TASK 1a Directory structure:
+    <TA1aperformer>_<run>
+        NIST
+            <document_id>.ttl                  (1 to X)
+		INTER-TA
+		    <document_id>.ttl                  (0 to X)
+
+    Ignores non ttl files.
+    Prints number of ttl files found, and number of ttl files that are in need to be checked.
+
+    :return: True if it appears submit ready, False otherwise
+    :rtype: bool
+    """
+
+    ttls_found_count = 0
+    ttls_error_warning_count = 0
+    ttls_valid_count = 0
+
+    for name in ARCHIVE_NAMES:
+
+        #split into levels
+        path_items = re.split('/', name)
+
+#TODO CHECK TA1A AND TA1B FOR IF PATH_ITEMS[-1] IS EVER NOT THE LOCATION OF THE .TTL FILE NAME
+
+        if '.ttl' in path_items[-1]:
+
+            ttls_found_count = ttls_found_count + 1
+
+            #validate that the ttl file is in an acceptable directory
+            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'nist', 'valid.ttl']
+            #rule: ttl needs to be in directory named nist, or inter-ta
+            try:
+                if ((path_items[-2].upper() == 'NIST' or path_items[-2].upper() == 'INTER-TA') and len(path_items) == 3):
+                    ttls_valid_count = ttls_valid_count + 1
+                else:
+                    ttls_error_warning_count = ttls_error_warning_count + 1
+            except:
+                ttls_error_warning_count = ttls_error_warning_count + 1
+
+    print("\nTA_1a Archive Validator report:")
+    print("INFO: TTL files found: " + str(ttls_found_count))
+    print("INFO: TTL files in valid locations: " + str(ttls_valid_count))
+    if ttls_error_warning_count > 0:
+        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        print(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
+
+    if ttls_found_count > 0 and ttls_error_warning_count == 0:
+        return True
+    return False
+
+
+def do_TA1b_check():
+    """
+    Task 1b directory structure:
+    <TA1performer>_<run>
+        NIST
+            hypothesisID			(1 to Y)
+                <document_id>.ttl 		(1 to X)
+
+    Ignores non ttl files.
+    Prints number of ttl files found, and number of ttl files that are in need to be checked.
+
+    :return: True if it appears submit ready, False otherwise
+    :rtype: bool
+    """
+    ttls_found_count = 0
+    ttls_error_warning_count = 0
+    ttls_valid_count = 0
+
+    for name in ARCHIVE_NAMES:
+
+        #split into levels
+        path_items = re.split('/', name)
+
+        if '.ttl' in path_items[-1]:
+
+            ttls_found_count = ttls_found_count + 1
+
+            #validate that the ttl file is in an acceptable directory
+            #rule: ttl needs to be in 3rd level -- aka 4th item in list['name', 'nist', 'hypothesis', 'valid.ttl']
+            #rule: ttl needs to be in a subdirectory within the nist directory
+            try:
+                if path_items[-3].upper() == 'NIST' or len(path_items) == 4:
+                    ttls_valid_count = ttls_valid_count + 1
+                else:
+                   ttls_error_warning_count = ttls_error_warning_count + 1
+            except:
+                ttls_error_warning_count = ttls_error_warning_count + 1
+
+    print("\nTA_1b Archive Validator report:")
+    print("INFO: TTL files found: " + str(ttls_found_count))
+    print("INFO: TTL files in valid locations: " + str(ttls_valid_count))
+    if ttls_error_warning_count > 0:
+        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        print("ttl files must be located the appropriate hypothesis_id subdirectory of the <run_ID>/NIST/ directory. i.e. <run_id>/NIST/<hypothesis_id>/file.ttl")
+
+    if ttls_found_count > 0 and ttls_error_warning_count == 0:
+        return True
+    return False
+
+
+def do_TA2_check():
+    """
+    Task 2 directory structure:
+    <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>
+        NIST
+            <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>.ttl	(1)
+        INTER-TA
+            <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>.ttl	(0 or 1)
+
+
+    Ignores non ttl files.
+    Prints number of ttl files found, and number of ttl files that are in need to be checked.
+
+    we do not check for all NIST standards set by the document, only for basic directory structure and a NIST/INTER-TA directory
+    :return: True if it appears submit ready, False otherwise
+    :rtype: bool
+    """
+
+    ttls_found_count = 0
+    ttls_error_warning_count = 0
+    ttls_valid_count = 0
+
+    for name in ARCHIVE_NAMES:
+
+        #split into levels
+        path_items = re.split('/', name)
+
+        if '.ttl' in path_items[-1]:
+
+            ttls_found_count = ttls_found_count + 1
+
+            #validate that the ttl file is in an acceptable directory
+            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'nist', 'valid.ttl']
+            #rule: ttl needs to be in directory named nist, or inter-ta
+            try:
+                if ((path_items[-2].upper() == 'NIST' or path_items[-2].upper() == 'INTER-TA') and len(path_items) == 3):
+                    ttls_valid_count = ttls_valid_count + 1
+                else:
+                    ttls_error_warning_count = ttls_error_warning_count + 1
+            except:
+                ttls_error_warning_count = ttls_error_warning_count + 1
+
+
+    print("\nTA_2 Archive Validator report:")
+    print("INFO: TTL files found: " + str(ttls_found_count))
+    print("INFO: TTL files in valid locations: " + str(ttls_valid_count))
+    if ttls_error_warning_count > 0:
+        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        print(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
+
+    if ttls_found_count > 0 and ttls_error_warning_count == 0:
+        return True
+    return False
+
+
+def do_TA3_check():
+    """
+    Task 3 directory structure:
+    <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>(-<TA2performer>_<run>).<TA3performer>_<run>
+        <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>(-<TA2performer>_<run>).<TA3performer>_<run>.<SIN ID>.<SIN frame ID>.<H followed by three digits>.ttl			(1 to X)
+
+    Ignores non ttl files.
+    Prints number of ttl files found, and number of ttl files that are in need to be checked.
+
+    we do not check for all NIST standards set by the document, only for basic directory structure.
+    :return: True if it appears submit ready, False otherwise
+    :rtype: bool
+    """
+
+    ttls_found_count = 0
+    ttls_error_warning_count = 0
+
+    for name in ARCHIVE_NAMES:
+        print(name)
+        #split into levels
+        path_items = re.split('/', name)
+        print(path_items)
+        if '.ttl' in path_items[-1]:
+
+            ttls_found_count = ttls_found_count + 1
+
+            #validate that the ttl file is in an acceptable directory
+            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'nist', 'valid.ttl']
+            #rule: ttl needs to be in directory named nist, or inter-ta
+
+            if len(path_items) is not 2:
+                ttls_error_warning_count = ttls_error_warning_count + 1
+
+    print("\nTA_3 Archive Validator report:")
+    print("INFO: TTL files found: " + str(ttls_found_count))
+    print("INFO: TTL files in valid locations: " + str(ttls_found_count - ttls_error_warning_count))
+    if ttls_error_warning_count > 0:
+        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        print(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
+
+    if ttls_found_count > 0 and ttls_error_warning_count == 0:
+        return True
+    return False
+
+
+def get_task_type(file, args):
+    """
+
+    :param file: the archive file
+    :param args: the runtime arguments for the program -- used to determine the task type
+    :return: int corresponding to the task type (see TASK_TYPE)
+    :rtype: int
+    """
+
+    #user did not tell us what task type it was, we must determine it ourselves.
+    #do this with counting the number of .'s in the filename (get rid of .tar.gz first though)
+    basename = os.path.basename(file)
+
+    #get rid of extra count if extention is .tar.gz
+    dot_count = basename.count('.') if not '.tar.gz' in basename else basename.count('.') - 1
+
+    if dot_count == 1:
+        #if theres 1 dot_count, we need to check to see if it is 1a or 1b.
+
+        '''
+        determining if 1a or 1b:
+            if .ttl file in "NIST" directory then 1a --> .*\/NIST\/[^\/]+.ttl   mode=/i
+            if directory in "NIST" directory and no .ttl in "NIST" directory, then 1b   --> .*\/NIST\/\S*\/\S*\.ttl mode =/i
+            
+        '''
+        #type count and ta1_temp used to determine if 1a or 1b
+        type_count = 0
+        ta1_ret_val = 0
+
+        names_str = " ".join(ARCHIVE_NAMES)
+        ta1a_dir_struct_regex = re.compile(".*\/NIST\/[^\/]+.ttl", re.IGNORECASE)
+        ta1b_dir_struct_regex = re.compile(".*\/NIST\/\S*\/\S*\.ttl", re.IGNORECASE)
+
+        #if ttls located in the nist directory, mark as potential TA_1a
+        if ta1a_dir_struct_regex.search(names_str) is not None:
+            ta1_ret_val = 0
+            type_count = type_count + 1
+        #if ttls located at some subdirectory of the nist directory, mark as potential TA_1b
+        if ta1b_dir_struct_regex.search(names_str) is not None:
+            ta1_ret_val = 1
+            type_count = type_count + 1
+        #if ttls were found in both the nist/ directory and a subdirectory of nist/, mark as TA_1a and have the ta_1a do this check too
+        if ta1_ret_val > -1 and type_count > 1 :        #use > and not == for scaleability? idk dont @ me c:
+            print ("WARNING: Subdirectories found at the same level of .ttl files in the NIST directory.")
+            ta1_ret_val = 0
+        return ta1_ret_val
+    elif dot_count > 1 and dot_count < 4:
+        return dot_count
+    else:
+        eprint("Unkown archive filetype. Please ensure archive name is properly titled per NIST guidelines.")
+        return -1
+
+
+
+def validate_archive_filetype(file):
+    """
+    Checks the input file type. If it is not a valid filetype, the program will
+    print an error message and quit the script.
+    Valid filetypes: .tgz, .tar.gz, or .zip.
+
+    :param file: path to file including file name and extention
+    :return: True if valid filetype and successfully set the global FILETYPE variable, False otherwise
+    :rtype: bool
+    """
+    global FILETYPE
+    file_ext = os.path.splitext(file)[-1].lower()
+    if file_ext == ".gz" or file_ext == ".tgz":
+        FILETYPE = 0
+    elif file_ext == ".zip":
+        FILETYPE = 1
+    else:
+        FILETYPE = -1
+        return False
+
+    return True
+
+def main():
+    """
+
+    :returns: True if script completed successfully, False otherwise
+    :rtype: bool
+    """
+    global FILETYPE
+    global TASK_TYPES
+    global ARCHIVE_NAMES
+
+    #ensure the archive type is a valid filetype and set the global FILETYPE value
+    if not validate_archive_filetype(sys.argv[1]) and FILETYPE >= 0:
+        eprint("FATAL ERROR: Archive filetype unknown. Please use .zip, .tgz, or .tar.gz")
+        exit(False)
+
+    #get names of items in the archive
+    if '-v' in sys.argv: print ("Gathering archive items...")
+    archive = zipfile.ZipFile(sys.argv[1], 'r', allowZip64=True) if FILETYPE else tarfile.open(sys.argv[1], mode='r')
+    ARCHIVE_NAMES = archive.namelist() if FILETYPE else archive.getnames()
+
+    task_type = get_task_type(sys.argv[1], sys.argv)
+    if task_type == -1:
+        eprint ("ERROR: Cannot determine the task type! Please input task type to arguments and run again.")
+        exit(False)
+
+    print("INFO: archive " + str(sys.argv[1]) + " is detected to be of Task type " + TASK_TYPES[task_type] + ".")
+
+    check_status = False
+    if task_type == 0:
+        check_status = do_TA1a_check()
+    elif task_type == 1:
+        check_status = do_TA1b_check()
+    elif task_type == 2:
+        check_status = do_TA2_check()
+    elif task_type == 3:
+        check_status = do_TA3_check()
+
+
+    is_or_not = " is " if check_status else " is not "
+    print(sys.argv[1] + is_or_not + "submit ready.")
+
+
+
+if __name__ == "__main__": main()

--- a/scripts/m18_submission_checker/README.md
+++ b/scripts/m18_submission_checker/README.md
@@ -1,13 +1,15 @@
-# See section 9 of the NIST AIDA 2019 Evaluation Plan V1.3 document for proper archive naming convention, formatting, and archive file types. #
+# See section 9 of the NIST AIDA 2019 Evaluation Plan document for proper archive naming convention, formatting, and archive file types. #
 
 This script is designed to help check if an archive is submit ready for M18 evaluation. 
-Submit ready means that the archive is structured properly for the AIF M18 batch validation process.
+"Submit ready" means that the archive is structured properly for the Next Century's automated AIF M18 batch validation process.
 
 This script checks that the ttl files are located in a valid directory structure (i.e. not in the base directory when expected to be in a /NIST/ directory).
 
 This script DOES NOT check for valid number of ttl files (i.e. will not find anything wrong with a TA 2 archive with more than 1 ttl in a /NIST/ directory).
 
 This script DOES NOT check that files in the /NIST/ directory are RESTRICTED AIF and that the files in the /INTER-TA/ directory are standard AIF, and so on. 
+
+This script DOES NOT do a complete check against all of the submission archives naming rules. However, it checks for the proper submission file name extension and the number of periods in the submission file name.
 
 ### To run: ###
 
@@ -16,7 +18,4 @@ This script DOES NOT check that files in the /NIST/ directory are RESTRICTED AIF
     python aida_m18_submission_checker.py <path/to/archive>
     
     
-Example usage and output for a valid TA_1a archive:
-    
-    $ python3 aida_m18_submission_checker.py /Users/njaffe/Documents/archives/OPERA_1.zip 
     

--- a/scripts/m18_submission_checker/README.md
+++ b/scripts/m18_submission_checker/README.md
@@ -19,11 +19,4 @@ This script DOES NOT check that files in the /NIST/ directory are RESTRICTED AIF
 Example usage and output for a valid TA_1a archive:
     
     $ python3 aida_m18_submission_checker.py /Users/njaffe/Documents/archives/OPERA_1.zip 
-    INFO:  Checking archive... this may take a moment for large files.
-    INFO:  archive /Users/njaffe/Documents/archives/OPERA_1.zip is detected to be of task type 1a.
-    INFO:  TA_1a Archive Validator report:
-    INFO:  TTL files found: 1653
-    INFO:  TTL files in valid locations: 1653
-    INFO:  Submission: /Users/njaffe/Documents/archives/OPERA_1.zip  is VALID and submit ready.
-    INFO:  Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a |
     

--- a/scripts/m18_submission_checker/README.md
+++ b/scripts/m18_submission_checker/README.md
@@ -1,0 +1,29 @@
+# See section 9 of the NIST AIDA 2019 Evaluation Plan V1.3 document for proper archive naming convention, formatting, and archive file types. #
+
+This script is designed to help check if an archive is submit ready for M18 evaluation. 
+Submit ready means that the archive is structured properly for the AIF M18 batch validation process.
+
+This script checks that the ttl files are located in a valid directory structure (i.e. not in the base directory when expected to be in a /NIST/ directory).
+
+This script DOES NOT check for valid number of ttl files (i.e. will not find anything wrong with a TA 2 archive with more than 1 ttl in a /NIST/ directory).
+
+This script DOES NOT check that files in the /NIST/ directory are RESTRICTED AIF and that the files in the /INTER-TA/ directory are standard AIF, and so on. 
+
+### To run: ###
+
+    python3 aida_m18_submission_checker.py <path/to/archive>
+    or
+    python aida_m18_submission_checker.py <path/to/archive>
+    
+    
+Example usage and output for a valid TA_1a archive:
+    
+    $ python3 aida_m18_submission_checker.py /Users/njaffe/Documents/archives/OPERA_1.zip 
+    INFO:  Checking archive... this may take a moment for large files.
+    INFO:  archive /Users/njaffe/Documents/archives/OPERA_1.zip is detected to be of task type 1a.
+    INFO:  TA_1a Archive Validator report:
+    INFO:  TTL files found: 1653
+    INFO:  TTL files in valid locations: 1653
+    INFO:  Submission: /Users/njaffe/Documents/archives/OPERA_1.zip  is VALID and submit ready.
+    INFO:  Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a | Task Type: 1a |
+    

--- a/scripts/m18_submission_checker/aida_m18_submission_checker.py
+++ b/scripts/m18_submission_checker/aida_m18_submission_checker.py
@@ -1,95 +1,200 @@
 '''
-This script is designed to parse an archive [.zip, .tgz, .tar.gz] and determine if it is properly structured, and will
-work with Next Century's validator.
 
-To run:
-python3 aida_m18_submission_checker.py <path/to/archive>
-
-Output will be printed to stdout and/or stderr
 '''
-import sys
-import os
-import tarfile, zipfile
-import re
-import logging
-
+import sys, os, re, logging, tarfile, zipfile
 
 '''
 Globals
 '''
-
-#variable to store if we use tar or zip method to access the file
-#-1 = error. cannot continue
-#0 = .tar.gz, or .tgz
-#1 = .zip
-FILETYPE = -1
-
-#task types to validate for
-TASK_TYPES = ["1a", "1b", "2", "3"]
-
-#the base name of the archive file
-ARCHIVE_FILE_NAME = ''
-
-#list of names of items in the archive - to be populated after determining what filetype the archive is
+# list of names of items in the archive - to be populated after determining what filetype the archive is
 ARCHIVE_NAMES = []
 
-def do_TA1a_check():
+warnings_dict = {'1a':".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory",
+                 '1b':".ttl files must be located the appropriate hypothesis_id subdirectory of the <run_ID>/NIST/ "
+                      "directory. i.e. <run_id>/NIST/<hypothesis_id>/file.ttl",
+                 '2':".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory",
+                 '3':".ttl files must be located in the <run_ID>/ directory" }
+
+
+
+def check_runtime_args(args):
     """
-    Check the archive
+    Checks the runtime arguments to ensure it is a file that exists. This function will log the errors detected, if any.
+    :param args: runtime arguments (sys.argv)
+    :return: True if valid runtime arguments, False otherwise
+    """
+
+    # check that an argument was given
+    if len(args) < 2:
+        logging.error("Missing archive file as argument.\nTo run: python3 aida_m18_submission_checker.py <path/to/archive>")
+        return False
+
+    # checks that argument is an existing file
+    if not os.path.isfile(args[1]):
+        logging.error("Argument is not a file.\nTo run: python3 aida_m18_submission_checker.py <path/to/archive>")
+        return False
+
+    return True
+
+def get_valid_archive_filetype(archive_file_name):
+    """
+    Checks the archive file type. If archive is not of valid file type, log an error message.
+    Valid filetypes: .tgz, .tar.gz, or .zip.
+
+    :return: string with archive filetype 'tar' or 'zip', or None if invalid filetype
+        (i.e. the library that should be used to read the archive)
+    :rtype: string, or None
+    """
+
+    if archive_file_name.endswith('.tar.gz') or archive_file_name.endswith('.tgz'):
+        return 'tar'
+    elif archive_file_name.endswith('.zip'):
+        return 'zip'
+    else:
+        logging.error("Archive filetype is unknown. Please use .zip, .tgz, or .tar.gz")
+        return None
+
+def get_archive_member_names(archive_file_name, archive_file_type):
+    """
+    Gets all of the file names/members of the archive.
+    :param archive_file_name: the file name/path of the archive
+    :param archive_file_type: the file extention type: 'tar' or 'zip'
+    :return: a list of the names/members in the archive on success, None if failure to open/read archive
+    :rtype: bool
+    """
+
+    logging.info("Checking archive... this may take a moment for large files.")
+
+    try:
+        archive = zipfile.ZipFile(archive_file_name, 'r', allowZip64=True) if archive_file_type == 'zip' else tarfile.open(archive_file_name, mode='r')
+        member_names_list = archive.namelist() if archive_file_type == 'zip' else archive.getnames()
+        return member_names_list
+    except:
+        # expected errors: (zipfile.BadZipFile, tarfile.ReadError), but catch all of them anyways
+        logging.error("Error thrown attempting to read/open the archive. Please use 'zip' or 'tar' to create your archive.")
+        return None
+
+def get_task_type(archive_file_name, archive_member_names):
+    """
+    :param archive_member_names: a list of members/names in the archive
+    :return: string corresponding to the task type, which could be any of the following: '1a', '1b', '2', or '3'
+    :rtype: string
+    """
+
+    # count the number of .'s in the archive file name to determine the task type. Hope the user has the proper naming convention
+    basename = os.path.basename(archive_file_name)
+
+    dot_count = basename.count('.')
+
+    # get rid of extra . count if the file extention is .tar.gz
+    if basename.endswith('.tar.gz'):
+        dot_count -= 1
+
+    if dot_count == 1:
+        # if theres only 1 dot_count, we need to check to see if it is 1a or 1b.
+
+        member_names_str = " ".join(archive_member_names)
+
+        # if .ttl file in "/NIST/" directory then ttls_under_nist_dir is not none (possible 1a)
+        ttls_under_nist_dir = re.compile(".*\/NIST\/[^\/]+.ttl", re.IGNORECASE).search(member_names_str)
+        # if ".ttl file in a subdirectory of /NIST/" then ttls_under_nist_subdir is not none (possible 1b)
+        ttls_under_nist_subdir = re.compile(".*\/NIST\/\S*\/\S*\.ttl", re.IGNORECASE).search(member_names_str)
+
+        if ttls_under_nist_dir is not None and ttls_under_nist_subdir is None:
+            return '1a'
+        elif ttls_under_nist_subdir is not None and ttls_under_nist_dir is None:
+            return '1b'
+        else:
+            # ttls found in /NIST/ and a subdirectory of /NIST/, so we cannot determine if 1a or 1b.
+            logging.warning("Cannot distinguish between 1a or 1b due to .ttl files existing at the same level as a subdirectory of /NIST/. \nContinuing as 1a.")
+            return '1a'
+            # ^^ change to return None if we want to stop processing rather than continue as 1a
+
+    elif dot_count == 2:
+        return '2'
+    elif dot_count == 3:
+        # else return the dot count if theres 2 or 3 dots
+        return '3'
+
+    else:
+        logging.error("Cannot determine the task type! Please input task type to arguments and run again.")
+        return None
+
+def get_archive_submit_ready_status_values(task_type, archive_member_names):
+    """
+    Prereq: ARCHIVE_FILE_NAME, and ARCHIVE_NAMES have been set
+
+    :return: returns dictionary with counts for total ttls found in archive, count of ttls in valid locations, and count of ttls in invalid locations
+    :rtype: dict {'total': x, 'valid' : y, 'invalid' : z}
+    """
+    ttls_total_count = 0
+    ttls_error_warning_count = 0
+    ttls_valid_count = 0
+
+    validity_check = None
+
+    # function pointer for which type of validity checking we want to do
+    if task_type == '1a' or task_type == '2':
+        validity_check = do_TA1a_2_check
+    elif task_type == '1b':
+        validity_check = do_TA1b_check
+    elif task_type == '3':
+        validity_check = do_TA3_check
+
+    for name in archive_member_names:
+
+        # split into levels
+        path_items = re.split('/', name)
+
+        # TODO CHECK IF PATH_ITEMS[-1] IS EVER NOT THE LOCATION OF THE .TTL FILE NAME
+
+        # if the current file is a .ttl file, check its validity and update counts
+        if path_items[-1].endswith('.ttl'):
+
+            ttls_total_count += 1
+
+            file_status = validity_check(path_items)
+
+            if file_status == True:
+                ttls_valid_count += 1
+            else:
+                ttls_error_warning_count += 1
+
+    return {'total' : ttls_total_count, 'valid' : ttls_valid_count, 'invalid' : ttls_error_warning_count}
+
+def do_TA1a_2_check(path_items):
+    """
+    Check the path in the archive to ensure the path is valid
     TASK 1a Directory structure:
     <TA1aperformer>_<run>
         NIST
-            <document_id>.ttl                  (1 to X)
+            <document_id>.ttl                  1a: (1 to X); 2: (1)
 		INTER-TA
-		    <document_id>.ttl                  (0 to X)
+		    <document_id>.ttl                  1a: (0 to X); 2: (0 or 1)
+
 
     Ignores non ttl files.
     Prints number of ttl files found, and number of ttl files that are in need to be checked.
 
-    :return: True if it appears submit ready, False otherwise
+    :param path_items: The path to the .ttl file that needs to be checked
+    :return: True if the file path is valid, False otherwise
     :rtype: bool
     """
 
-    ttls_found_count = 0
-    ttls_error_warning_count = 0
-    ttls_valid_count = 0
-
-    for name in ARCHIVE_NAMES:
-
-        #split into levels
-        path_items = re.split('/', name)
-
-#TODO CHECK TA1A AND TA1B FOR IF PATH_ITEMS[-1] IS EVER NOT THE LOCATION OF THE .TTL FILE NAME
-
-        if path_items[-1].endswith('.ttl'):
-
-            ttls_found_count += 1
-
-            #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
-            #rule: ttl needs to be in directory named NIST, or INTER-TA
-            try:
-                if ((path_items[-2] == 'NIST' or path_items[-2] == 'INTER-TA') and len(path_items) == 3):
-                    ttls_valid_count = ttls_valid_count + 1
-                else:
-                    ttls_error_warning_count += 1
-            except:
-                ttls_error_warning_count += 1
-
-    logging.info("\033[1mTA_1a\033[0m Archive Validator report:")
-    logging.info("TTL files found: " + str(ttls_found_count))
-    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
-    if ttls_error_warning_count > 0:
-        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        logging.error(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
-
-    if ttls_found_count > 0 and ttls_error_warning_count == 0:
-        return True
+    # validate that the ttl file is in an acceptable directory
+    # rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
+    # rule: ttl needs to be in directory named NIST, or INTER-TA
+    try:
+        if ((path_items[-2] == 'NIST' or path_items[-2] == 'INTER-TA') and len(path_items) == 3):
+            return True
+    except:
+        return False
     return False
 
 
-def do_TA1b_check():
+def do_TA1b_check(path_items):
     """
+    Check the path in the archive to ensure the path is valid
     Task 1b directory structure:
     <TA1performer>_<run>
         NIST
@@ -99,102 +204,24 @@ def do_TA1b_check():
     Ignores non ttl files.
     Prints number of ttl files found, and number of ttl files that are in need to be checked.
 
-    :return: True if it appears submit ready, False otherwise
-    :rtype: bool
-    """
-    ttls_found_count = 0
-    ttls_error_warning_count = 0
-    ttls_valid_count = 0
-
-    for name in ARCHIVE_NAMES:
-
-        #split into levels
-        path_items = re.split('/', name)
-
-        if path_items[-1].endswith('.ttl'):
-
-            ttls_found_count += 1
-
-            #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 3rd level -- aka 4th item in list['name', 'NIST', 'hypothesis', 'valid.ttl']
-            #rule: ttl needs to be in a subdirectory within the NIST directory
-            try:
-                if path_items[-3] == 'NIST' and len(path_items) == 4:
-                    ttls_valid_count = ttls_valid_count + 1
-                else:
-                   ttls_error_warning_count += 1
-            except:
-                ttls_error_warning_count += 1
-
-    logging.info("\033[1mTA_1b\033[0m Archive Validator report:")
-    logging.info("TTL files found: " + str(ttls_found_count))
-    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
-    if ttls_error_warning_count > 0:
-        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        logging.error("ttl files must be located the appropriate hypothesis_id subdirectory of the <run_ID>/NIST/ directory. i.e. <run_id>/NIST/<hypothesis_id>/file.ttl")
-
-    if ttls_found_count > 0 and ttls_error_warning_count == 0:
-        return True
-    return False
-
-
-def do_TA2_check():
-    """
-    Task 2 directory structure:
-    <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>
-        NIST
-            <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>.ttl	(1)
-        INTER-TA
-            <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>.ttl	(0 or 1)
-
-
-    Ignores non ttl files.
-    Prints number of ttl files found, and number of ttl files that are in need to be checked.
-
-    we do not check for all NIST standards set by the document, only for basic directory structure and a NIST/INTER-TA directory
-    :return: True if it appears submit ready, False otherwise
+    :param path_items: The path to the .ttl file that needs to be checked
+    :return: True if the file path is valid, False otherwise
     :rtype: bool
     """
 
-    ttls_found_count = 0
-    ttls_error_warning_count = 0
-    ttls_valid_count = 0
-
-    for name in ARCHIVE_NAMES:
-
-        #split into levels
-        path_items = re.split('/', name)
-
-        if path_items[-1].endswith('.ttl'):
-
-            ttls_found_count += 1
-
-            #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
-            #rule: ttl needs to be in directory named NIST, or INTER-TA
-            try:
-                if ((path_items[-2] == 'NIST' or path_items[-2] == 'INTER-TA') and len(path_items) == 3):
-                    ttls_valid_count = ttls_valid_count + 1
-                else:
-                    ttls_error_warning_count += 1
-            except:
-                ttls_error_warning_count += 1
-
-
-    logging.info("\033[1mTA_2\033[0m Archive Validator report:")
-    logging.info("TTL files found: " + str(ttls_found_count))
-    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
-    if ttls_error_warning_count > 0:
-        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        logging.error(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
-
-    if ttls_found_count > 0 and ttls_error_warning_count == 0:
-        return True
+    # validate that the ttl file is in an acceptable directory
+    # rule: ttl needs to be in 3rd level -- aka 4th item in list['name', 'NIST', 'hypothesis', 'valid.ttl']
+    # rule: ttl needs to be in a subdirectory within the NIST directory
+    try:
+        if path_items[-3] == 'NIST' and len(path_items) == 4:
+            return True
+    except:
+        return False
     return False
 
-
-def do_TA3_check():
+def do_TA3_check(path_items):
     """
+    Check the path in the archive to ensure the path is valid
     Task 3 directory structure:
     <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>(-<TA2performer>_<run>).<TA3performer>_<run>
         <TA1performer>_<run>(-<TA1performer>_<run>).<TA2performer>_<run>(-<TA2performer>_<run>).<TA3performer>_<run>.<SIN ID>.<SIN frame ID>.<H followed by three digits>.ttl			(1 to X)
@@ -203,181 +230,62 @@ def do_TA3_check():
     Prints number of ttl files found, and number of ttl files that are in need to be checked.
 
     we do not check for all NIST standards set by the document, only for basic directory structure.
-    :return: True if it appears submit ready, False otherwise
+    :param path_items: The path to the .ttl file that needs to be checked
+    :return: True if the file path is valid, False otherwise
     :rtype: bool
     """
 
-    ttls_found_count = 0
-    ttls_error_warning_count = 0
-    ttls_valid_count = 0
+    # validate that the ttl file is in an acceptable directory
+    # rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
+    # rule: ttl needs to be in directory named NIST, or INTER-TA
 
-    for name in ARCHIVE_NAMES:
-
-        #split into levels
-        path_items = re.split('/', name)
-
-        if path_items[-1].endswith('.ttl'):
-
-            ttls_found_count += 1
-
-            #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
-            #rule: ttl needs to be in directory named NIST, or INTER-TA
-
-            if len(path_items) == 2:
-                ttls_valid_count += 1
-            else:
-                ttls_error_warning_count += 1
-
-    logging.info("\033[1mTA_3\033[0m Archive Validator report:")
-    logging.info("TTL files found: " + str(ttls_found_count))
-    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
-    if ttls_error_warning_count > 0:
-        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        logging.error(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
-
-    if ttls_found_count > 0 and ttls_error_warning_count == 0:
-        return True
-    return False
+    return True if len(path_items) == 2 else False
 
 
-def get_task_type():
-    """
-    :return: int corresponding to the task type depending on the archive file name (see TASK_TYPE)
-    :rtype: int
-    """
-
-    #user did not tell us what task type it was, we must determine it ourselves.
-    #count the number of .'s in the archive file name to determine the task type. Hope the user has the proper naming convention.
-    basename = os.path.basename(ARCHIVE_FILE_NAME)
-
-    #get rid of extra . count if the file extention is .tar.gz
-    dot_count = basename.count('.') if not basename.endswith('.tar.gz') else basename.count('.') - 1
-
-    if dot_count == 1:
-        #if theres 1 dot_count, we need to check to see if it is 1a or 1b.
-
-        '''
-        determining if 1a or 1b:
-            if .ttl file in "NIST" directory then 1a --> .*\/NIST\/[^\/]+.ttl   mode=/i
-            if directory in "NIST" directory and no .ttl in "NIST" directory, then 1b   --> .*\/NIST\/\S*\/\S*\.ttl mode =/i
-            
-        '''
-        #type count and ta1_temp used to determine if 1a or 1b
-        type_count = 0
-        ta1_ret_val = 0
-
-        names_str = " ".join(ARCHIVE_NAMES)
-        ta1a_dir_struct_regex = re.compile(".*\/NIST\/[^\/]+.ttl", re.IGNORECASE)
-        ta1b_dir_struct_regex = re.compile(".*\/NIST\/\S*\/\S*\.ttl", re.IGNORECASE)
-
-        #if ttls located in the NIST directory, mark as potential TA_1a
-        if ta1a_dir_struct_regex.search(names_str) is not None:
-            ta1_ret_val = 0
-            type_count = type_count + 1
-        #if ttls located at some subdirectory of the NIST directory, mark as potential TA_1b
-        if ta1b_dir_struct_regex.search(names_str) is not None:
-            ta1_ret_val = 1
-            type_count = type_count + 1
-        #if ttls were found in both the NIST/ directory and a subdirectory of NIST/, mark as TA_1a and have the ta_1a do this check too
-        if ta1_ret_val > -1 and type_count > 1 :        #use > and not == for scaleability? idk dont @ me c:
-            logging.warning("WARNING: Subdirectories found at the same level of .ttl files in the NIST directory.")
-            ta1_ret_val = 0
-        return ta1_ret_val
-    elif dot_count > 1 and dot_count < 4:
-        return dot_count
-    else:
-        logging.error("Cannot figure out the TA level. Please ensure archive name is properly titled per NIST guidelines.")
-        return -1
-
-
-
-def validate_archive_filetype():
-    """
-    Checks the archive file type. If it is not a valid filetype, the program will
-    print an error message and quit the script.
-    Valid filetypes: .tgz, .tar.gz, or .zip.
-
-    :return: True if valid filetype and successfully set the global FILETYPE variable, False otherwise
-    :rtype: bool
-    """
-    global FILETYPE
-
-    if ARCHIVE_FILE_NAME.endswith('.tar.gz') or ARCHIVE_FILE_NAME.endswith('.tgz'):
-        FILETYPE = 0
-    elif ARCHIVE_FILE_NAME.endswith('.zip'):
-        FILETYPE = 1
-    else:
-        FILETYPE = -1
-        return False
-
-    return True
 
 def main():
     """
-
-    :returns: True if script completed successfully, False otherwise
+    :returns: True if script completed successfully (regardless if archive is submit ready or not)
+              False if script ran into a fatal error during execution and did not complete successfully.
     :rtype: bool
     """
-    global FILETYPE
-    global TASK_TYPES
-    global ARCHIVE_NAMES
-    global ARCHIVE_FILE_NAME
 
-    # set logging to log to stdout
+    # set logging to log/print INFO+ to stdout
     logging.basicConfig(level='INFO', format='%(levelname)s:  %(message)s')
 
-    #check runtime arguments
-    if len(sys.argv) < 2:
-        logging.error("Missing archive file as argument.\nTo run: python3 aida_m18_submission_checker.py <path/to/archive>")
-        return False
-    if not os.path.isfile(sys.argv[1]):
-        logging.error("Argument is not a file.\nTo run: python3 aida_m18_submission_checker.py <path/to/archive>")
+    if check_runtime_args(sys.argv) is False:
         return False
 
-    ARCHIVE_FILE_NAME = str(sys.argv[1])
+    archive_file_name = str(sys.argv[1])
 
-    #ensure the archive type is a valid filetype and set the global FILETYPE value
-    if validate_archive_filetype() < 0:
-        logging.critical("Archive filetype unknown. Please use .zip, .tgz, or .tar.gz")
+    archive_file_type = get_valid_archive_filetype(archive_file_name)
+
+    if archive_file_type is None:
         return False
 
-    #get names of items in the archive
-    try:
-        logging.info("Checking archive... this may take a moment for large files.")
-        archive = zipfile.ZipFile(ARCHIVE_FILE_NAME, 'r', allowZip64=True) if FILETYPE else tarfile.open(ARCHIVE_FILE_NAME, mode='r')
-        ARCHIVE_NAMES = archive.namelist() if FILETYPE == 1 else archive.getnames()
-    except:
-        #expected errors: (zipfile.BadZipFile, tarfile.ReadError), but catch all of them anyways
-        logging.critical("Error thrown attempting to read/open the archive. Please use 'zip' or 'tar' to create your archive.")
+    archive_member_names = get_archive_member_names(archive_file_name, archive_file_type)
+
+    if archive_member_names is None:
         return False
 
-
-    task_type = get_task_type()
-    if task_type == -1:
-        logging.error("Cannot determine the task type! Please input task type to arguments and run again.")
+    task_type = get_task_type(archive_file_name, archive_member_names)
+    if task_type == None:
         return False
 
-    logging.info("archive " + str(ARCHIVE_FILE_NAME) + " is detected to be of task type \033[1m" + TASK_TYPES[task_type] + "\033[0m.")
+    logging.info("Archive " + str(archive_file_name) + " is detected to be of task type " + task_type + ".")
 
-    check_status = False
-    if task_type == 0:
-        check_status = do_TA1a_check()
-    elif task_type == 1:
-        check_status = do_TA1b_check()
-    elif task_type == 2:
-        check_status = do_TA2_check()
-    elif task_type == 3:
-        check_status = do_TA3_check()
+    archive_status = get_archive_submit_ready_status_values(task_type, archive_member_names)
 
+    # log archive report
+    logging.info("M18 Submission Checker Report for: \n\t{0}".format(archive_file_name))
+    logging.info("Total .ttl files found in submission archive: {0}".format(archive_status['total']))
+    logging.info("Total number of .ttl files to be validated: {0}".format(archive_status['valid']))
+    if archive_status['invalid'] > 0:
+        logging.warning("Total number of .ttl files located in invalid locations and will not be validated: {0}".format(archive_status['invalid']))
+        logging.warning(warnings_dict[task_type])
+    elif archive_status['total'] > 0:   # dont want them accidentally submitting 0
+        logging.info("{0} is VALID and submit ready according to task {1} rules!".format(archive_file_name, task_type))
 
-    is_or_not = " is " if check_status else " is not "
-    result_str = "\033[1mVALID\033[0m and submit ready." if check_status else "\033[1mINVALID\033[0m."
-    logging.info("Submission: " + ARCHIVE_FILE_NAME + " is " + result_str)
-
-    logging.info("Task Type: \033[1m{0}\033[0m | ".format(TASK_TYPES[task_type]) * 10)
-
-    return check_status
-
+    return True
 
 if __name__ == "__main__": main()

--- a/scripts/m18_submission_checker/aida_m18_submission_checker.py
+++ b/scripts/m18_submission_checker/aida_m18_submission_checker.py
@@ -7,11 +7,11 @@ python3 aida_m18_submission_checker.py <path/to/archive>
 
 Output will be printed to stdout and/or stderr
 '''
-import sys                  #for sys.args
-from sys import exit as exit
-import os                   #for extention access (basename)
-import tarfile, zipfile     #for archive access
-import re                   #for regex
+import sys
+import os
+import tarfile, zipfile
+import re
+import logging
 
 
 '''
@@ -27,21 +27,11 @@ FILETYPE = -1
 #task types to validate for
 TASK_TYPES = ["1a", "1b", "2", "3"]
 
+#the base name of the archive file
+ARCHIVE_FILE_NAME = ''
+
 #list of names of items in the archive - to be populated after determining what filetype the archive is
 ARCHIVE_NAMES = []
-
-
-def eprint(*args, **kwargs):
-    """simple function to print to stderr
-
-    :param args: data to print
-    :param kwargs: keywords to pass in print args
-    """
-    #*****************
-    # REQUIRES PYTHON 3+
-    #*****************
-    print(*args, file=sys.stderr, **kwargs)
-
 
 def do_TA1a_check():
     """
@@ -71,27 +61,27 @@ def do_TA1a_check():
 
 #TODO CHECK TA1A AND TA1B FOR IF PATH_ITEMS[-1] IS EVER NOT THE LOCATION OF THE .TTL FILE NAME
 
-        if '.ttl' in path_items[-1]:
+        if path_items[-1].endswith('.ttl'):
 
-            ttls_found_count = ttls_found_count + 1
+            ttls_found_count += 1
 
             #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'nist', 'valid.ttl']
-            #rule: ttl needs to be in directory named nist, or inter-ta
+            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
+            #rule: ttl needs to be in directory named NIST, or INTER-TA
             try:
-                if ((path_items[-2].upper() == 'NIST' or path_items[-2].upper() == 'INTER-TA') and len(path_items) == 3):
+                if ((path_items[-2] == 'NIST' or path_items[-2] == 'INTER-TA') and len(path_items) == 3):
                     ttls_valid_count = ttls_valid_count + 1
                 else:
-                    ttls_error_warning_count = ttls_error_warning_count + 1
+                    ttls_error_warning_count += 1
             except:
-                ttls_error_warning_count = ttls_error_warning_count + 1
+                ttls_error_warning_count += 1
 
-    print("\nTA_1a Archive Validator report:")
-    print("INFO: TTL files found: " + str(ttls_found_count))
-    print("INFO: TTL files in valid locations: " + str(ttls_valid_count))
+    logging.info("\033[1mTA_1a\033[0m Archive Validator report:")
+    logging.info("TTL files found: " + str(ttls_found_count))
+    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
     if ttls_error_warning_count > 0:
-        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        print(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
+        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        logging.error(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
 
     if ttls_found_count > 0 and ttls_error_warning_count == 0:
         return True
@@ -121,27 +111,27 @@ def do_TA1b_check():
         #split into levels
         path_items = re.split('/', name)
 
-        if '.ttl' in path_items[-1]:
+        if path_items[-1].endswith('.ttl'):
 
-            ttls_found_count = ttls_found_count + 1
+            ttls_found_count += 1
 
             #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 3rd level -- aka 4th item in list['name', 'nist', 'hypothesis', 'valid.ttl']
-            #rule: ttl needs to be in a subdirectory within the nist directory
+            #rule: ttl needs to be in 3rd level -- aka 4th item in list['name', 'NIST', 'hypothesis', 'valid.ttl']
+            #rule: ttl needs to be in a subdirectory within the NIST directory
             try:
-                if path_items[-3].upper() == 'NIST' or len(path_items) == 4:
+                if path_items[-3] == 'NIST' and len(path_items) == 4:
                     ttls_valid_count = ttls_valid_count + 1
                 else:
-                   ttls_error_warning_count = ttls_error_warning_count + 1
+                   ttls_error_warning_count += 1
             except:
-                ttls_error_warning_count = ttls_error_warning_count + 1
+                ttls_error_warning_count += 1
 
-    print("\nTA_1b Archive Validator report:")
-    print("INFO: TTL files found: " + str(ttls_found_count))
-    print("INFO: TTL files in valid locations: " + str(ttls_valid_count))
+    logging.info("\033[1mTA_1b\033[0m Archive Validator report:")
+    logging.info("TTL files found: " + str(ttls_found_count))
+    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
     if ttls_error_warning_count > 0:
-        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        print("ttl files must be located the appropriate hypothesis_id subdirectory of the <run_ID>/NIST/ directory. i.e. <run_id>/NIST/<hypothesis_id>/file.ttl")
+        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        logging.error("ttl files must be located the appropriate hypothesis_id subdirectory of the <run_ID>/NIST/ directory. i.e. <run_id>/NIST/<hypothesis_id>/file.ttl")
 
     if ttls_found_count > 0 and ttls_error_warning_count == 0:
         return True
@@ -175,28 +165,28 @@ def do_TA2_check():
         #split into levels
         path_items = re.split('/', name)
 
-        if '.ttl' in path_items[-1]:
+        if path_items[-1].endswith('.ttl'):
 
-            ttls_found_count = ttls_found_count + 1
+            ttls_found_count += 1
 
             #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'nist', 'valid.ttl']
-            #rule: ttl needs to be in directory named nist, or inter-ta
+            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
+            #rule: ttl needs to be in directory named NIST, or INTER-TA
             try:
-                if ((path_items[-2].upper() == 'NIST' or path_items[-2].upper() == 'INTER-TA') and len(path_items) == 3):
+                if ((path_items[-2] == 'NIST' or path_items[-2] == 'INTER-TA') and len(path_items) == 3):
                     ttls_valid_count = ttls_valid_count + 1
                 else:
-                    ttls_error_warning_count = ttls_error_warning_count + 1
+                    ttls_error_warning_count += 1
             except:
-                ttls_error_warning_count = ttls_error_warning_count + 1
+                ttls_error_warning_count += 1
 
 
-    print("\nTA_2 Archive Validator report:")
-    print("INFO: TTL files found: " + str(ttls_found_count))
-    print("INFO: TTL files in valid locations: " + str(ttls_valid_count))
+    logging.info("\033[1mTA_2\033[0m Archive Validator report:")
+    logging.info("TTL files found: " + str(ttls_found_count))
+    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
     if ttls_error_warning_count > 0:
-        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        print(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
+        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        logging.error(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
 
     if ttls_found_count > 0 and ttls_error_warning_count == 0:
         return True
@@ -219,50 +209,50 @@ def do_TA3_check():
 
     ttls_found_count = 0
     ttls_error_warning_count = 0
+    ttls_valid_count = 0
 
     for name in ARCHIVE_NAMES:
-        print(name)
+
         #split into levels
         path_items = re.split('/', name)
-        print(path_items)
-        if '.ttl' in path_items[-1]:
 
-            ttls_found_count = ttls_found_count + 1
+        if path_items[-1].endswith('.ttl'):
+
+            ttls_found_count += 1
 
             #validate that the ttl file is in an acceptable directory
-            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'nist', 'valid.ttl']
-            #rule: ttl needs to be in directory named nist, or inter-ta
+            #rule: ttl needs to be in 2nd level -- aka 3rd item in list['name', 'NIST', 'valid.ttl']
+            #rule: ttl needs to be in directory named NIST, or INTER-TA
 
-            if len(path_items) is not 2:
-                ttls_error_warning_count = ttls_error_warning_count + 1
+            if len(path_items) == 2:
+                ttls_valid_count += 1
+            else:
+                ttls_error_warning_count += 1
 
-    print("\nTA_3 Archive Validator report:")
-    print("INFO: TTL files found: " + str(ttls_found_count))
-    print("INFO: TTL files in valid locations: " + str(ttls_found_count - ttls_error_warning_count))
+    logging.info("\033[1mTA_3\033[0m Archive Validator report:")
+    logging.info("TTL files found: " + str(ttls_found_count))
+    logging.info("TTL files in valid locations: " + str(ttls_valid_count))
     if ttls_error_warning_count > 0:
-        print("ERROR: TTL files found in an invalid location: " + str(ttls_error_warning_count))
-        print(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
+        logging.error("TTL files found in an invalid location: " + str(ttls_error_warning_count))
+        logging.error(".ttl files must be located in either the <run_ID>/NIST/ or <run_id>/INTER-TA directory")
 
     if ttls_found_count > 0 and ttls_error_warning_count == 0:
         return True
     return False
 
 
-def get_task_type(file, args):
+def get_task_type():
     """
-
-    :param file: the archive file
-    :param args: the runtime arguments for the program -- used to determine the task type
-    :return: int corresponding to the task type (see TASK_TYPE)
+    :return: int corresponding to the task type depending on the archive file name (see TASK_TYPE)
     :rtype: int
     """
 
     #user did not tell us what task type it was, we must determine it ourselves.
-    #do this with counting the number of .'s in the filename (get rid of .tar.gz first though)
-    basename = os.path.basename(file)
+    #count the number of .'s in the archive file name to determine the task type. Hope the user has the proper naming convention.
+    basename = os.path.basename(ARCHIVE_FILE_NAME)
 
-    #get rid of extra count if extention is .tar.gz
-    dot_count = basename.count('.') if not '.tar.gz' in basename else basename.count('.') - 1
+    #get rid of extra . count if the file extention is .tar.gz
+    dot_count = basename.count('.') if not basename.endswith('.tar.gz') else basename.count('.') - 1
 
     if dot_count == 1:
         #if theres 1 dot_count, we need to check to see if it is 1a or 1b.
@@ -281,42 +271,41 @@ def get_task_type(file, args):
         ta1a_dir_struct_regex = re.compile(".*\/NIST\/[^\/]+.ttl", re.IGNORECASE)
         ta1b_dir_struct_regex = re.compile(".*\/NIST\/\S*\/\S*\.ttl", re.IGNORECASE)
 
-        #if ttls located in the nist directory, mark as potential TA_1a
+        #if ttls located in the NIST directory, mark as potential TA_1a
         if ta1a_dir_struct_regex.search(names_str) is not None:
             ta1_ret_val = 0
             type_count = type_count + 1
-        #if ttls located at some subdirectory of the nist directory, mark as potential TA_1b
+        #if ttls located at some subdirectory of the NIST directory, mark as potential TA_1b
         if ta1b_dir_struct_regex.search(names_str) is not None:
             ta1_ret_val = 1
             type_count = type_count + 1
-        #if ttls were found in both the nist/ directory and a subdirectory of nist/, mark as TA_1a and have the ta_1a do this check too
+        #if ttls were found in both the NIST/ directory and a subdirectory of NIST/, mark as TA_1a and have the ta_1a do this check too
         if ta1_ret_val > -1 and type_count > 1 :        #use > and not == for scaleability? idk dont @ me c:
-            print ("WARNING: Subdirectories found at the same level of .ttl files in the NIST directory.")
+            logging.warning("WARNING: Subdirectories found at the same level of .ttl files in the NIST directory.")
             ta1_ret_val = 0
         return ta1_ret_val
     elif dot_count > 1 and dot_count < 4:
         return dot_count
     else:
-        eprint("Unkown archive filetype. Please ensure archive name is properly titled per NIST guidelines.")
+        logging.error("Cannot figure out the TA level. Please ensure archive name is properly titled per NIST guidelines.")
         return -1
 
 
 
-def validate_archive_filetype(file):
+def validate_archive_filetype():
     """
-    Checks the input file type. If it is not a valid filetype, the program will
+    Checks the archive file type. If it is not a valid filetype, the program will
     print an error message and quit the script.
     Valid filetypes: .tgz, .tar.gz, or .zip.
 
-    :param file: path to file including file name and extention
     :return: True if valid filetype and successfully set the global FILETYPE variable, False otherwise
     :rtype: bool
     """
     global FILETYPE
-    file_ext = os.path.splitext(file)[-1].lower()
-    if file_ext == ".gz" or file_ext == ".tgz":
+
+    if ARCHIVE_FILE_NAME.endswith('.tar.gz') or ARCHIVE_FILE_NAME.endswith('.tgz'):
         FILETYPE = 0
-    elif file_ext == ".zip":
+    elif ARCHIVE_FILE_NAME.endswith('.zip'):
         FILETYPE = 1
     else:
         FILETYPE = -1
@@ -333,23 +322,43 @@ def main():
     global FILETYPE
     global TASK_TYPES
     global ARCHIVE_NAMES
+    global ARCHIVE_FILE_NAME
+
+    # set logging to log to stdout
+    logging.basicConfig(level='INFO', format='%(levelname)s:  %(message)s')
+
+    #check runtime arguments
+    if len(sys.argv) < 2:
+        logging.error("Missing archive file as argument.\nTo run: python3 aida_m18_submission_checker.py <path/to/archive>")
+        return False
+    if not os.path.isfile(sys.argv[1]):
+        logging.error("Argument is not a file.\nTo run: python3 aida_m18_submission_checker.py <path/to/archive>")
+        return False
+
+    ARCHIVE_FILE_NAME = str(sys.argv[1])
 
     #ensure the archive type is a valid filetype and set the global FILETYPE value
-    if not validate_archive_filetype(sys.argv[1]) and FILETYPE >= 0:
-        eprint("FATAL ERROR: Archive filetype unknown. Please use .zip, .tgz, or .tar.gz")
-        exit(False)
+    if validate_archive_filetype() < 0:
+        logging.critical("Archive filetype unknown. Please use .zip, .tgz, or .tar.gz")
+        return False
 
     #get names of items in the archive
-    if '-v' in sys.argv: print ("Gathering archive items...")
-    archive = zipfile.ZipFile(sys.argv[1], 'r', allowZip64=True) if FILETYPE else tarfile.open(sys.argv[1], mode='r')
-    ARCHIVE_NAMES = archive.namelist() if FILETYPE else archive.getnames()
+    try:
+        logging.info("Checking archive... this may take a moment for large files.")
+        archive = zipfile.ZipFile(ARCHIVE_FILE_NAME, 'r', allowZip64=True) if FILETYPE else tarfile.open(ARCHIVE_FILE_NAME, mode='r')
+        ARCHIVE_NAMES = archive.namelist() if FILETYPE == 1 else archive.getnames()
+    except:
+        #expected errors: (zipfile.BadZipFile, tarfile.ReadError), but catch all of them anyways
+        logging.critical("Error thrown attempting to read/open the archive. Please use 'zip' or 'tar' to create your archive.")
+        return False
 
-    task_type = get_task_type(sys.argv[1], sys.argv)
+
+    task_type = get_task_type()
     if task_type == -1:
-        eprint ("ERROR: Cannot determine the task type! Please input task type to arguments and run again.")
-        exit(False)
+        logging.error("Cannot determine the task type! Please input task type to arguments and run again.")
+        return False
 
-    print("INFO: archive " + str(sys.argv[1]) + " is detected to be of Task type " + TASK_TYPES[task_type] + ".")
+    logging.info("archive " + str(ARCHIVE_FILE_NAME) + " is detected to be of task type \033[1m" + TASK_TYPES[task_type] + "\033[0m.")
 
     check_status = False
     if task_type == 0:
@@ -363,8 +372,12 @@ def main():
 
 
     is_or_not = " is " if check_status else " is not "
-    print(sys.argv[1] + is_or_not + "submit ready.")
+    result_str = "\033[1mVALID\033[0m and submit ready." if check_status else "\033[1mINVALID\033[0m."
+    logging.info("Submission: " + ARCHIVE_FILE_NAME + " is " + result_str)
 
+    logging.info("Task Type: \033[1m{0}\033[0m | ".format(TASK_TYPES[task_type]) * 10)
+
+    return check_status
 
 
 if __name__ == "__main__": main()

--- a/scripts/m18_submission_checker/aida_m18_submission_checker.py
+++ b/scripts/m18_submission_checker/aida_m18_submission_checker.py
@@ -282,9 +282,11 @@ def main():
     logging.info("M18 Submission Checker Report for: \n\t{0}".format(archive_file_name))
     logging.info("Total .ttl files found in submission archive: {0}".format(archive_status['total']))
     logging.info("Total number of .ttl files to be validated: {0}".format(archive_status['valid']))
+    #if they have ttls located in invalid locations, print the warning
     if archive_status['invalid'] > 0:
         logging.warning("Total number of .ttl files located in invalid locations and will not be validated: {0}".format(archive_status['invalid']))
-        logging.warning(warnings_dict[task_type])
+        logger_print_level = logging.warning if archive_status['valid'] > 0 else logging.error
+        logger_print_level(warnings_dict[task_type])
     if archive_status['total'] > 0 and archive_status['valid'] > 0:   # dont want them accidentally submitting 0
         logging.info("{0} is VALID and submit ready according to task {1} rules!".format(archive_file_name, task_type))
 

--- a/scripts/m18_submission_checker/aida_m18_submission_checker.py
+++ b/scripts/m18_submission_checker/aida_m18_submission_checker.py
@@ -1,6 +1,6 @@
 """
 aida_m18_submission_checker.py
-June 20th, 2019
+June 21st, 2019
 
 to run:
     python3 aida_m18_submission_checker.py <path/to/archive>

--- a/scripts/m18_submission_checker/aida_m18_submission_checker.py
+++ b/scripts/m18_submission_checker/aida_m18_submission_checker.py
@@ -1,7 +1,9 @@
-'''
-
-'''
-import sys, os, re, logging, tarfile, zipfile
+import sys
+import os
+import re
+import logging
+import tarfile
+import zipfile
 
 '''
 Globals
@@ -283,7 +285,7 @@ def main():
     if archive_status['invalid'] > 0:
         logging.warning("Total number of .ttl files located in invalid locations and will not be validated: {0}".format(archive_status['invalid']))
         logging.warning(warnings_dict[task_type])
-    elif archive_status['total'] > 0:   # dont want them accidentally submitting 0
+    if archive_status['total'] > 0 and archive_status['valid'] > 0:   # dont want them accidentally submitting 0
         logging.info("{0} is VALID and submit ready according to task {1} rules!".format(archive_file_name, task_type))
 
     return True

--- a/scripts/m18_submission_checker/aida_m18_submission_checker.py
+++ b/scripts/m18_submission_checker/aida_m18_submission_checker.py
@@ -287,7 +287,7 @@ def main():
         logging.warning("Total number of .ttl files located in invalid locations and will not be validated: {0}".format(archive_status['invalid']))
         logger_print_level = logging.warning if archive_status['valid'] > 0 else logging.error
         logger_print_level(warnings_dict[task_type])
-    if archive_status['total'] > 0 and archive_status['valid'] > 0:   # dont want them accidentally submitting 0
+    if archive_status['valid'] > 0:
         logging.info("{0} is VALID and submit ready according to task {1} rules!".format(archive_file_name, task_type))
 
     return True


### PR DESCRIPTION
Linked to ticket AIDA-871

### Description:
This is designed to be a standalone python3 script that can be sent out to performers so that they can run it on their archives and check if their archive is submit ready. Submit ready means that the archive is structured properly for the AIF M18 batch validation process. 

#### To test: 

- Ensure that the task type was determined correctly; 
- that the output is clear as to which task type the archive was checked for; 
- that the program does not raise false positives in where it states an archive is submit ready when it should not be. 

#### To run:
`python3 aida_m18_submission_checker.py <path/to/archive>`

