### PR TITLE
AIDA-888:  shallow validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ validate N files or all files in a specified directory.
 To run the validator from the command line, run `target/appassembler/bin/validateAIF`
 with a series of command-line arguments (in any order) honoring the following usage:  <br>
 Usage:  <br>
-`validateAIF [-hov] [--ldc] [--nist] [--nist-ta3] [--pm] [--program] [--abort[=num]] [-d=DIRNAME] [-t=num] [--ont=FILE...]... [-f=FILE...]...`  <br>
+`validateAIF [-hov] [--ldc] [--nist] [--nist-ta3] [--pm] [--program] [--abort[=num]] [--depth[=num]] [-d=DIRNAME] [-t=num] [--ont=FILE...]... [-f=FILE...]...`  <br>
 
 | Switch | Description |
 | ----------- | ----------- |
@@ -69,6 +69,7 @@ Usage:  <br>
 |`--nist` | validate against the NIST restrictions |
 |`--nist-ta3` | validate against the NIST hypothesis restrictions (implies `--nist`) |
 |`--abort[=num]` | Abort validation after `[num]` SHACL violations (num > 2), or three violations if `[num]` is omitted. |
+|`--depth[=num]` | Perform shallow validation in which each SHACL rule (shape) is only applied to `[num]` target nodes, or 50 nodes if `[num]` is omitted (requires -t). |
 |`--pm` | Enable progress monitor that shows ongoing validation progress |
 |`--disk` | Use disk-based model for validating very large files |
 |`-o` | Save validation report model to a file.  `KB.ttl` would result in `KB-report.txt`. Output defaults to stderr. |

--- a/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
+++ b/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
@@ -191,8 +191,6 @@ public class ThreadedValidationEngine extends ValidationEngine {
 
                 if (maxDepth > 0 && filteredCount > maxDepth) {
                     filtered = filtered.subList(0, maxDepth-1);
-                    String label = getLabelFunction().apply(shape.getShapeResource());
-                    System.out.printf("Truncating shape# %d (%s) to %d, node size = %d.\n", id, label, maxDepth, filteredCount);
                 }
 
                 if (!filtered.isEmpty()) {

--- a/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -59,6 +59,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     static final String ERR_MISSING_FILE_FLAG = "Must use one of these flags: -f | -d";
     static final String ERR_TOO_MANY_FILE_FLAGS = "Can only use one of these flags: -f | -d";
     static final String ERR_SMALLER_THAN_MIN = "%s must be at least %d";
+    static final String ERR_BAD_ARGTYPE = "%s is not a(n) %s";
     static final String ERR_DEPTH_REQUIRES_T = "--depth requires -t with at least 2 threads";
     // Logging strings
     static final String START_MSG = "AIF Validator";
@@ -73,6 +74,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     private static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
     // ViolationThreshold
     private static final String ABORT_PARAMETER_STRING = "Abort parameter";
+    private static final int DEFAULT_MAX_VIOLATIONS = 3;
     private static final int MINIMUM_MAX_VIOLATIONS = 3;
     // Depth
     private static final String DEPTH_PARAMETER_STRING = "Depth parameter";
@@ -117,9 +119,9 @@ public class ValidateAIFCli implements Callable<Integer> {
         @Override
         public Integer convert(String value) {
             try {
-                return "".equals(value) ? MINIMUM_MAX_VIOLATIONS : Integer.parseInt(value);
+                return "".equals(value) ? DEFAULT_MAX_VIOLATIONS : Integer.parseInt(value);
             } catch (Exception ex) {
-                throw new CommandLine.TypeConversionException(String.format("'%s' is not an %s", value, Integer.TYPE.getSimpleName()));
+                throw new CommandLine.TypeConversionException(String.format(ERR_BAD_ARGTYPE, value, Integer.TYPE.getSimpleName()));
             }
         }
     }
@@ -135,7 +137,7 @@ public class ValidateAIFCli implements Callable<Integer> {
             try {
                 return "".equals(value) ? DEFAULT_DEPTH : Integer.parseInt(value);
             } catch (Exception ex) {
-                throw new CommandLine.TypeConversionException(String.format("'%s' is not an %s", value, Integer.TYPE.getSimpleName()));
+                throw new CommandLine.TypeConversionException(String.format(ERR_BAD_ARGTYPE, value, Integer.TYPE.getSimpleName()));
             }
         }
     }

--- a/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -59,7 +59,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     static final String ERR_MISSING_FILE_FLAG = "Must use one of these flags: -f | -d";
     static final String ERR_TOO_MANY_FILE_FLAGS = "Can only use one of these flags: -f | -d";
     static final String ERR_SMALLER_THAN_MIN = "%s must be at least %d";
-    static final String ERR_DEPTH_REQUIRES_T = "--depth requires -t";
+    static final String ERR_DEPTH_REQUIRES_T = "--depth requires -t with at least 2 threads";
     // Logging strings
     static final String START_MSG = "AIF Validator";
     // Version

--- a/src/test/java/com/ncc/aif/ValidateCLITest.java
+++ b/src/test/java/com/ncc/aif/ValidateCLITest.java
@@ -91,7 +91,12 @@ public class ValidateCLITest {
     }
 
     @Nested
-    class ThresholdArgument {
+    class AbortArgument {
+        @Test
+        void thresholdBadType() {
+            expectUsageError(ValidateAIFCli.ERR_BAD_ARGTYPE.replaceAll("%.", ""),
+                    "--ldc", "--abort", "foobar", "-f", "tmp.ttl");
+        }
         @Test
         void thresholdTooLow() {
             expectUsageError(ValidateAIFCli.ERR_SMALLER_THAN_MIN.replaceAll("%.", ""),
@@ -101,10 +106,35 @@ public class ValidateCLITest {
         void correctThreshold() {
             expectCorrect("--ldc", "--abort", "4", "-f", "tmp.ttl");
         }
-
         @Test
         void correctThresholdWithoutValue() {
             expectCorrect("--ldc", "--abort", "-f", "tmp.ttl");
+        }
+    }
+
+    @Nested
+    class DepthArgument {
+        @Test
+        void depthBadType() {
+            expectUsageError(ValidateAIFCli.ERR_BAD_ARGTYPE.replaceAll("%.", ""),
+                    "--ldc", "--depth", "foobar", "-t", "2", "-f", "tmp.ttl");
+        }
+        @Test
+        void depthTooLow() {
+            expectUsageError(ValidateAIFCli.ERR_SMALLER_THAN_MIN.replaceAll("%.", ""),
+                    "--ldc", "--depth", "-1", "-t=2", "-f", "tmp.ttl");
+        }
+        @Test
+        void correctDepth() {
+            expectCorrect("--ldc", "--depth", "1", "-t=2", "-f", "tmp.ttl");
+        }
+        @Test
+        void requiresMultithreads() {
+            expectUsageError(ValidateAIFCli.ERR_DEPTH_REQUIRES_T, "--ldc", "--depth", "-f", "tmp.ttl");
+        }
+        @Test
+        void correctDepthWithoutValue() {
+            expectCorrect("--ldc", "--depth", "-t=2", "-f", "tmp.ttl");
         }
     }
 


### PR DESCRIPTION
The `--depth` option performs a “shallow” validation in which each SHACL rule (shape) only considers a subset of its target nodes.

Notes:
- Specifying `--depth=-1` doesn't get rejected and performs a regular validation.  This is a picocli quirk as -1 is the "default" value.  The same thing happens with `--abort`.  Maybe I'll fix this...thoughts?
--> **Update:  fixed this.**
- I left in a line of debugging so you can see shallow validation "in action."  Obviously I'll remove it prior to merge.
- I'm not sure what a good default depth value is.  Thoughts?
- Test in combination with `--abort`, `-p`, `--p2`, `--disk`, and whatever other options you see fit.