### PR TITLE
Aida 902

### DIFF
--- a/docker/batch-init/scripts/init-scheduler.py
+++ b/docker/batch-init/scripts/init-scheduler.py
@@ -92,6 +92,9 @@ def read_envs():
     envs['BATCH_JOB_QUEUE'] = os.environ.get('BATCH_JOB_QUEUE')
     envs['AWS_SNS_TOPIC_ARN'] = os.environ.get('AWS_SNS_TOPIC_ARN')
     envs['AWS_DEFAULT_REGION'] = os.environ.get('AWS_DEFAULT_REGION')
+    envs['NIST_VALIDATION_FLAGS'] = os.environ.get('NIST_VALIDATION_FLAGS', '--ldc --nist -o')
+    envs['UNRESTRICTED_VALIDATION_FLAGS'] = os.environ.get('UNRESTRICTED_VALIDATION_FLAGS', '--ldc -o')
+    envs['NIST_TA3_VALIDATION_FLAGS'] = os.environ.get('NIST_TA3_VALIDATION_FLAGS', '--ldc --nist-ta3 -o')
 
     return envs
 
@@ -119,7 +122,10 @@ def main():
     		'BATCH_JOB_DEFINITION': envs['BATCH_JOB_DEFINITION'],
     		'BATCH_JOB_QUEUE': envs['BATCH_JOB_QUEUE'],
     		'AWS_SNS_TOPIC_ARN': envs['AWS_SNS_TOPIC_ARN'],
-            'AWS_DEFAULT_REGION': envs['AWS_DEFAULT_REGION']
+            'AWS_DEFAULT_REGION': envs['AWS_DEFAULT_REGION'],
+            'NIST_VALIDATION_FLAGS': envs['NIST_VALIDATION_FLAGS'],
+            'UNRESTRICTED_VALIDATION_FLAGS': envs['UNRESTRICTED_VALIDATION_FLAGS'],
+            'NIST_TA3_VALIDATION_FLAGS': envs['NIST_TA3_VALIDATION_FLAGS']
     	}
 
     	# get the full list of submissions located in the bucket/prefix

--- a/docker/batch-init/scripts/init.py
+++ b/docker/batch-init/scripts/init.py
@@ -21,9 +21,9 @@ class Task(Enum):
 class Initialize:
 
 	# define all the different directory types and corresponding flags
-	NIST = { 'validation': '--ldc --nist -o', 'name': 'nist', 'description': 'NIST RESTRICTED'  }
-	INTER_TA = { 'validation': '--ldc -o', 'name': 'unrestricted', 'description': 'UNRESTRICTED'  }
-	NIST_TA3 = { 'validation': '--ldc --nist-ta3 -o', 'name': 'nist-ta3', 'description': 'NIST TA3 RESTRICTED' }
+	NIST = { 'name': 'nist', 'description': 'NIST RESTRICTED'  }
+	INTER_TA = { 'name': 'unrestricted', 'description': 'UNRESTRICTED'  }
+	NIST_TA3 = { 'name': 'nist-ta3', 'description': 'NIST TA3 RESTRICTED' }
 
 	# init instance attributes
 	def __init__(self, envs):
@@ -37,6 +37,11 @@ class Initialize:
 		self.batch_job_definition = envs['BATCH_JOB_DEFINITION']
 		self.batch_job_queue = envs['BATCH_JOB_QUEUE']
 		self.session = boto3.session.Session(region_name=self.aws_region)
+
+		# set validation flags for different submission types
+		self.NIST['validation'] = envs['NIST_VALIDATION_FLAGS']
+		self.INTER_TA['validation'] = envs['UNRESTRICTED_VALIDATION_FLAGS']
+		self.NIST_TA3['validation'] = envs['NIST_TA3_VALIDATION_FLAGS']
 
 
 	def run(self):
@@ -694,6 +699,9 @@ def read_envs():
 	envs['BATCH_JOB_QUEUE'] = os.environ.get('BATCH_JOB_QUEUE')
 	envs['AWS_SNS_TOPIC_ARN'] = os.environ.get('AWS_SNS_TOPIC_ARN')
 	envs['AWS_DEFAULT_REGION'] = os.environ.get('AWS_DEFAULT_REGION')
+	envs['NIST_VALIDATION_FLAGS'] = os.environ.get('NIST_VALIDATION_FLAGS', '--ldc --nist -o')
+	envs['UNRESTRICTED_VALIDATION_FLAGS'] = os.environ.get('UNRESTRICTED_VALIDATION_FLAGS', '--ldc -o')
+	envs['NIST_TA3_VALIDATION_FLAGS'] = os.environ.get('NIST_TA3_VALIDATION_FLAGS', '--ldc --nist-ta3 -o')
 
 	return envs
 

--- a/infrastructure/aida-validation-batch-single-cf-template.json
+++ b/infrastructure/aida-validation-batch-single-cf-template.json
@@ -134,14 +134,9 @@
             "Description": "Ec2KeyPair to use for Compute Environment",
             "Default": "AIDA-All"
         },
-        "MainEc2InstanceType": {
+        "Ec2InstanceType": {
             "Type": "String",
             "Description": "The EC2 instance type for the main node",
-            "Default": "m4.large"
-        },
-        "WorkerEc2InstanceType": {
-            "Type": "String",
-            "Description": "The EC2 instance type for the worker node",
             "Default": "m4.large"
         },
         "MainContainerImage": {
@@ -241,8 +236,7 @@
                         "Ref": "BatchInstanceProfile"
                     },
                     "InstanceTypes": [
-                        { "Ref": "MainEc2InstanceType" },
-                        { "Ref": "WorkerEc2InstanceType" }
+                        { "Ref": "Ec2InstanceType" }
                     ],
                     "MaxvCpus": {
                         "Ref": "ComputeEnvironmentMaxVCpus"
@@ -502,7 +496,7 @@
                                     "Ref": "MainContainerImage"
                                 },
                                 "InstanceType" : {
-                                    "Ref": "MainEc2InstanceType"
+                                    "Ref": "Ec2InstanceType"
                                 },
                                 "JobRoleArn" : {
                                     "Ref": "BatchTaskRole"
@@ -557,7 +551,7 @@
                                     "Ref": "WorkerContainerImage"
                                 },
                                 "InstanceType" : {
-                                    "Ref": "WorkerEc2InstanceType"
+                                    "Ref": "Ec2InstanceType"
                                 },
                                 "JobRoleArn" : {
                                     "Ref": "BatchTaskRole"


### PR DESCRIPTION
- Updated init.py and init-scheduler.py to allow for configurable validation flags to be passed in at run-time for NIST, INTER_TA, and NIST_TA3 submissions. 
- Updated the batch single Cloudformation script to only contain a single EC2 instance type parameter. AWS Batch does not allow for different instances types between the worker and main nodes so having parameters for each was redundant. 