### PR TITLE
Aida 907

### DIFF
--- a/docker/batch-init/scripts/init-scheduler.py
+++ b/docker/batch-init/scripts/init-scheduler.py
@@ -56,7 +56,9 @@ def validate_envs(envs: dict):
         return False
 
     for k, v in envs.items():
-        if not is_env_set(k, v):
+
+        # JAVA OPTS is not required to be set
+        if not is_env_set(k, v) and k is not 'JAVA_OPTS':
             return False
 
     return True
@@ -70,6 +72,12 @@ def is_env_set(env, value):
     :returns: True if environment variable is set, False otherwise
     :rtype: bool
     """
+
+    # JAVA OPTS is not required to be set
+    if env is 'JAVA_OPTS':
+        logging.info("Environment variable JAVA_OPTS is set to %s", value)
+        return True
+
     if not value:
         logging.error("Environment variable %s is not set", env)
         return False
@@ -95,6 +103,7 @@ def read_envs():
     envs['NIST_VALIDATION_FLAGS'] = os.environ.get('NIST_VALIDATION_FLAGS', '--ldc --nist -o')
     envs['UNRESTRICTED_VALIDATION_FLAGS'] = os.environ.get('UNRESTRICTED_VALIDATION_FLAGS', '--ldc -o')
     envs['NIST_TA3_VALIDATION_FLAGS'] = os.environ.get('NIST_TA3_VALIDATION_FLAGS', '--ldc --nist-ta3 -o')
+    envs['JAVA_OPTS'] = os.environ.get('JAVA_OPTS')
 
     return envs
 
@@ -125,7 +134,8 @@ def main():
             'AWS_DEFAULT_REGION': envs['AWS_DEFAULT_REGION'],
             'NIST_VALIDATION_FLAGS': envs['NIST_VALIDATION_FLAGS'],
             'UNRESTRICTED_VALIDATION_FLAGS': envs['UNRESTRICTED_VALIDATION_FLAGS'],
-            'NIST_TA3_VALIDATION_FLAGS': envs['NIST_TA3_VALIDATION_FLAGS']
+            'NIST_TA3_VALIDATION_FLAGS': envs['NIST_TA3_VALIDATION_FLAGS'],
+            'JAVA_OPTS': envs['JAVA_OPTS']
     	}
 
     	# get the full list of submissions located in the bucket/prefix

--- a/docker/batch-init/scripts/init-scheduler.py
+++ b/docker/batch-init/scripts/init-scheduler.py
@@ -58,7 +58,7 @@ def validate_envs(envs: dict):
     for k, v in envs.items():
 
         # JAVA OPTS is not required to be set
-        if not is_env_set(k, v) and k is not 'JAVA_OPTS':
+        if not is_env_set(k, v):
             return False
 
     return True

--- a/docker/batch-init/scripts/init-scheduler.py
+++ b/docker/batch-init/scripts/init-scheduler.py
@@ -57,7 +57,6 @@ def validate_envs(envs: dict):
 
     for k, v in envs.items():
 
-        # JAVA OPTS is not required to be set
         if not is_env_set(k, v):
             return False
 

--- a/docker/batch-single/scripts/worker.py
+++ b/docker/batch-single/scripts/worker.py
@@ -438,6 +438,7 @@ def read_envs():
 	envs['AWS_BATCH_JOB_ID'] = os.environ.get('AWS_BATCH_JOB_ID')
 	envs['AWS_BATCH_JOB_NODE_INDEX'] = os.environ.get('AWS_BATCH_JOB_NODE_INDEX')
 	envs['AWS_DEFAULT_REGION'] = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
+
 	return envs
 
 
@@ -470,6 +471,9 @@ def validate_envs(envs):
     except ValueError:
         logging.error("Validation timeout [%s] must be an integer", envs['VALIDATION_TIMEOUT'])
         return False
+
+    # print out JAVA_OPTS for logging purposes
+    logging.info("Envrionment variable JAVA_OPTS is set to %s", os.environ.get('JAVA_OPTS'))
 
     return True
 

--- a/infrastructure/aida-validation-batch-single-cf-template.json
+++ b/infrastructure/aida-validation-batch-single-cf-template.json
@@ -41,6 +41,11 @@
             "Value": {
                 "Ref": "BatchTaskRole"
             }
+        },
+        "JavaOpts": {
+            "Value": {
+                "Ref": "EnvJavaOpts"
+            }
         }
     },
     "Parameters": {
@@ -209,14 +214,18 @@
         },
     	"EnvValidationHome": {
     	    "Type": "String",
-                "Description": "The local path of the AIF Validator on the docker container",
-                "Default": "/opt/aif-validator"
+            "Description": "The local path of the AIF Validator on the docker container",
+            "Default": "/opt/aif-validator"
     	},
     	"EnvValidationFlags": {
     	    "Type": "String",
-                "Description": "A single string that contains the flags to pass to the AIF Validator upon execution",
-                "Default": "--ldc --nist -o"
-    	}
+            "Description": "A single string that contains the flags to pass to the AIF Validator upon execution",
+            "Default": "--ldc --nist -o"
+    	},
+        "EnvJavaOpts": {
+            "Type": "String",
+            "Description": "Optionally set the JAVA_OPTS environment variable"
+        }
     },
     "Resources": {
         "BatchComputeEnvironment": {
@@ -545,6 +554,10 @@
                                     {
                                         "Name": "S3_SUBMISSION_BUCKET",
                                         "Value": { "Ref": "EnvS3SubmissionBucket" }
+                                    }, 
+                                    {
+                                        "Name": "JAVA_OPTS",
+                                        "Value": { "Ref": "EnvJavaOpts" }
                                     }
                                 ],
                                 "Image" : {

--- a/infrastructure/aida-validation-network-cf-template.json
+++ b/infrastructure/aida-validation-network-cf-template.json
@@ -18,6 +18,14 @@
       			"Name": "aida-validation-vpc-id"
         	}
         },
+        "AvailabilityZone": {
+        	"Value": {
+        		"Ref": "AvailabilityZone"
+        	},
+        	"Export": {
+        		"Name": "aida-validation-availability-zone"
+        	}
+        },
         "PublicSubnetA": {
             "Value": {
                 "Ref": "PublicSubnetA"
@@ -84,6 +92,11 @@
             "MaxLength": "18",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "Must be valid CIDR notation (e.g. x.x.x.x/x)."
+        },
+        "AvailabilityZone" : {
+        	"Type": "String",
+        	"Description": "The availability zone where the subnets will be created",
+        	"Default": "us-east-1a"
         },
         "PublicSubnetACidr": {
         	"Type": "String",
@@ -178,6 +191,7 @@
 		"PublicSubnetA": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},
@@ -274,6 +288,7 @@
 		"PrivateSubnetA": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},
@@ -292,6 +307,7 @@
 		"PrivateSubnetB": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},
@@ -310,6 +326,7 @@
 		"PrivateSubnetC": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},
@@ -328,6 +345,7 @@
 		"PrivateSubnetD": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},
@@ -346,6 +364,7 @@
 		"PrivateSubnetE": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},
@@ -364,6 +383,7 @@
 		"PrivateSubnetF": {
 			"Type": "AWS::EC2::Subnet",
 			"Properties": {
+				"AvailabilityZone": { "Ref": "AvailabilityZone" },
 				"VpcId": {
 					"Ref": "VPC"
 				},


### PR DESCRIPTION
- Updated batch-init init.py and init-scheduler.py to take in JAVA_OPTS as an environment variable and pass it to the batch-single worker batch job submission
- Updated batch-single worker.py to log what JAVA_OPTS is set to for the current run on that node
- Updated the Cloudformation batch-single template to accept JAVA_OPTS as a parameter and apply it to the worker node environment variables
- Updated the Cloudformation batch-single template to deploy everything in a configurable availability zone, defaulting to us-east-1a because other availability zones did not support special instance types like r5.12xlarge. 