### PR TITLE
AIDA-894: incorporate AIDA-893 into v1.0.x

### DIFF
--- a/python/aida_interchange/aifutils.py
+++ b/python/aida_interchange/aifutils.py
@@ -259,7 +259,7 @@ def make_relation(g, relation_uri, system):
     :param str relation_uri: A unique string URI for the relation
     :param rdflib.term.URIRef system: The system object for the system which created the 
         specified relation
-    :returns: The relaton object
+    :returns: The relation object
     :rtype: rdflib.term.URIRef  
     """
     return _make_aif_resource(g, relation_uri, AIDA_ANNOTATION.Relation, system)
@@ -543,7 +543,7 @@ def make_shot_video_justification(g, doc_id, shot_id, system, confidence,
     :param str doc_id: A string containing the document element (child) ID of the 
         source of the justification
     :param str shot_id: The string Id of the shot of the specified video document
-    :param rdflib.term.URIRef system: TThe system object for the system which made
+    :param rdflib.term.URIRef system: The system object for the system which made
         this justification
     :param float confidence: The confidence with which to mark the justification
     :param str uri_ref: A string URI representation of the video justification (Default is None)
@@ -570,7 +570,7 @@ def mark_shot_video_justification(g, things_to_justify, doc_id, shot_id, system,
     :param str shot_id: The string Id of the shot of the specified video document
     :param str doc_id: A string containing the document element (child) ID of the
         source of the justification
-    :param rdflib.term.URIRef system: TThe system object for the system which made 
+    :param rdflib.term.URIRef system: The system object for the system which made
         this justification
     :param float confidence: The confidence with which to mark the justification
     :param str uri_ref: A string URI representation of the video justification (Default is None)

--- a/python/aida_interchange/aifutils.py
+++ b/python/aida_interchange/aifutils.py
@@ -13,6 +13,7 @@ A convenient interface for creating simple AIF graphs.
 More complicated graphs will require direct manipulation of the RDF
 """
 
+
 def make_graph():
     """
     Creates the underlying RDF model
@@ -78,6 +79,7 @@ def mark_text_value(g, entity, text_value):
     """
     g.add((entity, AIDA_ANNOTATION.textValue,
            Literal(text_value, datatype=XSD.string)))
+
 
 def mark_numeric_value_as_string(g, entity, numeric_value):
     """
@@ -212,7 +214,7 @@ def mark_text_justification(g, things_to_justify, doc_id, start_offset,
     Mark multiple things as being justified by a particular snippet of text.
 
     :param rdflib.graph.Graph g: The underlying RDF model
-    :param list things_to_justify: A list of resources to be marked by the specified text 
+    :param list things_to_justify: A list of resources to be marked by the specified text
         document
     :param str doc_id: A string containing the document element (child) ID of the source of 
         the justification
@@ -348,8 +350,8 @@ def mark_boundingbox(g, to_mark_on, boundingbox):
     :param rdflib.graph.Graph g: The underlying RDF model
     :param rdflib.term.BNode to_mark_on: The resource to mark with the specified bounding
         box
-    :param rdflib.term.URIRef system: The system object for the system which marked this
-         bounding box
+    :param Bounding_Box boundingbox: A rectangular box
+        within the image that bounds the justification
     """
     bounding_box_resource = BNode()
     g.add((bounding_box_resource, RDF.type, AIDA_ANNOTATION.BoundingBox))
@@ -540,9 +542,11 @@ def make_shot_video_justification(g, doc_id, shot_id, system, confidence,
     :param rdflib.graph.Graph g: The underlying RDF model
     :param str doc_id: A string containing the document element (child) ID of the 
         source of the justification
-    :param rdflib.term.URIRef system: TThe system object for the system which made 
+    :param str shot_id: The string Id of the shot of the specified video document
+    :param rdflib.term.URIRef system: TThe system object for the system which made
         this justification
     :param float confidence: The confidence with which to mark the justification
+    :param str uri_ref: A string URI representation of the video justification (Default is None)
     :returns: The created video justification resource
     :rtype: rdflib.term.BNode
     """
@@ -563,11 +567,13 @@ def mark_shot_video_justification(g, things_to_justify, doc_id, shot_id, system,
     :param rdflib.graph.Graph g: The underlying RDF model
     :param list things_to_justify: A list of resources to be marked by the specified 
         video document
-    :param str doc_id: A string containing the document element (child) ID of the 
+    :param str shot_id: The string Id of the shot of the specified video document
+    :param str doc_id: A string containing the document element (child) ID of the
         source of the justification
     :param rdflib.term.URIRef system: TThe system object for the system which made 
         this justification
     :param float confidence: The confidence with which to mark the justification
+    :param str uri_ref: A string URI representation of the video justification (Default is None)
     :returns: The created video justification resource
     :rtype: rdflib.term.BNode
     """
@@ -596,6 +602,7 @@ def mark_compound_justification(g, things_to_justify, justifications, system, co
         g.add((compound_justification, AIDA_ANNOTATION.containedJustification, justification))
     mark_justification(g, things_to_justify, compound_justification)
     return compound_justification
+
 
 def add_source_document_to_justification(g, justification, source_document) :
     """
@@ -636,7 +643,8 @@ def make_cluster_with_prototype(g, cluster_uri, prototype, system, handle=None):
         g.add((cluster, AIDA_ANNOTATION.handle, Literal(handle, datatype=XSD.string)))
     return cluster
 
-def mark_as_possible_cluster_member(g, possible_cluster_member, cluster, confidence, system):
+
+def mark_as_possible_cluster_member(g, possible_cluster_member, cluster, confidence, system, uri_ref=None):
     """
     Mark an entity or event as a possible member of a cluster.
 
@@ -646,10 +654,11 @@ def mark_as_possible_cluster_member(g, possible_cluster_member, cluster, confide
     :param rdflib.term.URIRef cluster: The cluster to associate with the possible cluster member
     :param float confidence: The confidence with which to mark the cluster membership
     :param rdflib.term.URIRef system: The system object for the system which marked the specified cluster
+    :param str uri_ref: A string URI representation of the cluster member (Default is None)
     :returns: The cluster membership assertion
     :rtype: rdflib.term.BNode
     """
-    cluster_member_assertion = _make_aif_resource(g, None, AIDA_ANNOTATION.ClusterMembership, system)
+    cluster_member_assertion = _make_aif_resource(g, uri_ref, AIDA_ANNOTATION.ClusterMembership, system)
     g.add((cluster_member_assertion, AIDA_ANNOTATION.cluster, cluster))
     g.add((cluster_member_assertion, AIDA_ANNOTATION.clusterMember, possible_cluster_member))
     mark_confidence(g, cluster_member_assertion, confidence, system)
@@ -701,10 +710,10 @@ def mark_informative_justification(g, resource, informative_justification):
     Mark resource as having an informativeJustification value
 
     :param rdflib.graph.Graph g: The underlying RDF model
-    :param resource: the resource to mark with the specified imporatance
+    :param resource: the resource to mark with the specified importance
     :param informative_justification: the justification which will be considered informative
     """
-    g.add((resource, AIDA_ANNOTATION.informativeJustification , informative_justification))
+    g.add((resource, AIDA_ANNOTATION.informativeJustification, informative_justification))
 
 
 def mark_depends_on_hypothesis(g, depender, hypothesis):
@@ -713,7 +722,7 @@ def mark_depends_on_hypothesis(g, depender, hypothesis):
 
     :param rdflib.graph.Graph g: The underlying RDF model
     :param rdflib.term.URIRef depender: the argument that depends on the specified hypothesis
-    :param rdflib.term.URIRef hyptothesis: The hypothesis upon which to depend
+    :param rdflib.term.URIRef hypothesis: The hypothesis upon which to depend
     """
     g.add((depender, AIDA_ANNOTATION.dependsOnHypothesis, hypothesis))
 
@@ -793,6 +802,7 @@ def mark_private_data(g, resource, json_content, system):
 
     return private_data
 
+
 def mark_private_data_with_vector(g, resource, system, vector):
     """
     Mark data as private from vector data. Private data should not contain document-level content features.
@@ -823,6 +833,7 @@ def mark_private_data_with_vector(g, resource, system, vector):
     vector = json.dumps(vector)
     private_data = mark_private_data(g, resource, str(vector), system)
     return private_data
+
 
 def link_to_external_kb(g, to_link, external_kb_id, system, confidence):
     """
@@ -889,6 +900,7 @@ def _make_aif_justification(g, doc_id, class_type, system, confidence,
     mark_confidence(g, justification, confidence, system)
     return justification
 
+
 _TYPE_QUERY = prepareQuery("""SELECT ?typeAssertion WHERE {
   ?typeAssertion a rdf:Statement .
   ?typeAssertion rdf:predicate rdf:type .
@@ -931,7 +943,7 @@ def mark_ldc_time(g, to_mark, start, end, system):
     Add LDC start and end time representation to an Event or Relation
 
     :param rdflib.graph.Graph g: The underlying RDF model
-    :param rdflib.term.URIRef to_mark: The Event or Realtion to add the LDC time data to
+    :param rdflib.term.URIRef to_mark: The Event or Relation to add the LDC time data to
     :param LDCTimeComponent start: containing the start time information
     :param LDCTimeComponent end: containing the end time information
     :param rdflib.term.URIRef  system: The system object for the system which marks the time

--- a/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/src/main/java/com/ncc/aif/AIFUtils.java
@@ -268,8 +268,8 @@ public class AIFUtils {
 
     // Helper function to create a justification (text, image, audio, etc.) in the system.
     private static Resource makeAIFJustification(Model model, String docId, Resource classType,
-                                                 Resource system, Double confidence) {
-        final Resource justification = makeAIFResource(model, null, classType, system);
+                                                 Resource system, Double confidence, String uri) {
+        final Resource justification = makeAIFResource(model, uri, classType, system);
         justification.addProperty(AidaAnnotationOntology.SOURCE, model.createTypedLiteral(docId));
         markConfidence(model, justification, confidence, system);
         return justification;
@@ -308,6 +308,23 @@ public class AIFUtils {
      */
     public static Resource makeTextJustification(Model model, String docId, int startOffset, int endOffsetInclusive,
                                                  Resource system, Double confidence) {
+        return makeTextJustification(model, docId, startOffset, endOffsetInclusive, system, confidence, null);
+    }
+
+    /**
+     * Create a justification from a particular snippet of text.
+     *
+     * @param model              The underlying RDF model for the operation
+     * @param docId              A string containing the document element (child) ID of the source of the justification
+     * @param startOffset        An integer offset within the document for the start of the justification
+     * @param endOffsetInclusive An integer offset within the document for the end of the justification
+     * @param system             The system object for the system which made this justification
+     * @param confidence         The confidence with which to mark the justification
+     * @param uri                A String uri representation of the justification
+     * @return The created text justification resource
+     */
+    public static Resource makeTextJustification(Model model, String docId, int startOffset, int endOffsetInclusive,
+                                                 Resource system, Double confidence, String uri) {
         if (endOffsetInclusive < startOffset) {
             throw new IllegalArgumentException("End offset " + endOffsetInclusive + " precedes start offset " + startOffset);
         }
@@ -316,7 +333,7 @@ public class AIFUtils {
         }
 
         final Resource justification = makeAIFJustification(model, docId, AidaAnnotationOntology.TEXT_JUSTIFICATION_CLASS,
-                system, confidence);
+                system, confidence, uri);
         // the document ID for the justifying source document
         justification.addProperty(AidaAnnotationOntology.START_OFFSET,
                 model.createTypedLiteral(startOffset));
@@ -342,7 +359,27 @@ public class AIFUtils {
                                                  int startOffset, int endOffsetInclusive,
                                                  Resource system, Double confidence) {
         return markTextJustification(model, ImmutableSet.of(toMarkOn), docId, startOffset,
-                endOffsetInclusive, system, confidence);
+                endOffsetInclusive, system, confidence, null);
+    }
+
+    /**
+     * Mark something as being justified by a particular snippet of text.
+     *
+     * @param model              The underlying RDF model for the operation
+     * @param toMarkOn           The Resource to be marked by the specified text document
+     * @param docId              A string containing the document element (child) ID of the source of the justification
+     * @param startOffset        An integer offset within the document for start of the justification
+     * @param endOffsetInclusive An integer offset within the document for the end of the justification
+     * @param system             The system object for the system which marked this justification
+     * @param confidence         The confidence with which to mark the justification
+     * @param uri                A String uri representation of the text justification
+     * @return The created text justification resource
+     */
+    public static Resource markTextJustification(Model model, Resource toMarkOn, String docId,
+                                                 int startOffset, int endOffsetInclusive,
+                                                 Resource system, Double confidence, String uri) {
+        return markTextJustification(model, ImmutableSet.of(toMarkOn), docId, startOffset,
+                endOffsetInclusive, system, confidence, uri);
     }
 
     /**
@@ -360,7 +397,26 @@ public class AIFUtils {
     public static Resource markTextJustification(Model model, Collection<Resource> toMarkOn, String docId,
                                                  int startOffset, int endOffsetInclusive,
                                                  Resource system, Double confidence) {
-        final Resource justification = makeTextJustification(model, docId, startOffset, endOffsetInclusive, system, confidence);
+        return markTextJustification(model, toMarkOn, docId, startOffset, endOffsetInclusive, system, confidence, null);
+    }
+
+    /**
+     * Mark multiple things as being justified by a particular snippet of text.
+     *
+     * @param model              The underlying RDF model for the operation
+     * @param toMarkOn           A Collection of Resources to be marked by the specified text document
+     * @param docId              A string containing the document element (child) ID of the source of the justification
+     * @param startOffset        An integer offset within the document for start of the justification
+     * @param endOffsetInclusive An integer offset within the document for the end of the justification
+     * @param system             The system object for the system which marked this justification
+     * @param confidence         The confidence with which to mark the justification
+     * @param uri                A String uri representation of the text justification
+     * @return The created text justification resource
+     */
+    public static Resource markTextJustification(Model model, Collection<Resource> toMarkOn, String docId,
+                                                 int startOffset, int endOffsetInclusive,
+                                                 Resource system, Double confidence, String uri) {
+        final Resource justification = makeTextJustification(model, docId, startOffset, endOffsetInclusive, system, confidence, uri);
         markJustification(toMarkOn, justification);
         return justification;
     }
@@ -513,8 +569,24 @@ public class AIFUtils {
      */
     public static Resource makeImageJustification(Model model, String docId, BoundingBox boundingBox, Resource system,
                                                   Double confidence) {
+        return makeImageJustification(model, docId, boundingBox, system, confidence, null);
+    }
+
+    /**
+     * Make an image justification.
+     *
+     * @param model       The underlying RDF model for the operation
+     * @param docId       A string containing the document element (child) ID of the source of the justification
+     * @param boundingBox A rectangular box within the image that bounds the justification
+     * @param system      The system object for the system which made this justification
+     * @param confidence  The confidence with which to mark the justification
+     * @param uri         A String uri representation of the justification
+     * @return The created image justification resource
+     */
+    public static Resource makeImageJustification(Model model, String docId, BoundingBox boundingBox, Resource system,
+                                                  Double confidence, String uri) {
         final Resource justification = makeAIFJustification(model, docId, AidaAnnotationOntology.IMAGE_JUSTIFICATION_CLASS,
-                system, confidence);
+                system, confidence, uri);
         markBoundingBox(model, justification, boundingBox);
         return justification;
     }
@@ -532,7 +604,24 @@ public class AIFUtils {
      */
     public static Resource markImageJustification(Model model, Resource toMarkOn, String docId,
                                                   BoundingBox boundingBox, Resource system, Double confidence) {
-        return markImageJustification(model, ImmutableSet.of(toMarkOn), docId, boundingBox, system, confidence);
+        return markImageJustification(model, ImmutableSet.of(toMarkOn), docId, boundingBox, system, confidence, null);
+    }
+
+    /**
+     * Mark something as being justified by a particular image.
+     *
+     * @param model       The underlying RDF model for the operation
+     * @param toMarkOn    The Resource to be marked by the specified image document
+     * @param docId       A string containing the document element (child) ID of the source of the justification
+     * @param boundingBox A rectangular box within the image that bounds the justification
+     * @param system      The system object for the system which marked this justification
+     * @param confidence  The confidence with which to mark the justification
+     * @param uri         A String uri representation of the justification
+     * @return The created image justification resource
+     */
+    public static Resource markImageJustification(Model model, Resource toMarkOn, String docId,
+                                                  BoundingBox boundingBox, Resource system, Double confidence, String uri) {
+        return markImageJustification(model, ImmutableSet.of(toMarkOn), docId, boundingBox, system, confidence, uri);
     }
 
     /**
@@ -548,7 +637,24 @@ public class AIFUtils {
      */
     public static Resource markImageJustification(Model model, Collection<Resource> toMarkOn, String docId,
                                                   BoundingBox boundingBox, Resource system, Double confidence) {
-        final Resource justification = makeImageJustification(model, docId, boundingBox, system, confidence);
+        return markImageJustification(model, toMarkOn, docId, boundingBox, system, confidence, null);
+    }
+
+    /**
+     * Mark multiple things as being justified by a particular image.
+     *
+     * @param model       The underlying RDF model for the operation
+     * @param toMarkOn    A Collection of Resources to be marked by the specified image document
+     * @param docId       A string containing the document element (child) ID of the source of the justification
+     * @param boundingBox A rectangular box within the image that bounds the justification
+     * @param system      The system object for the system which made this justification
+     * @param confidence  The confidence with which to mark the justification
+     * @param uri         A String uri representation of the justification
+     * @return The created image justification resource
+     */
+    public static Resource markImageJustification(Model model, Collection<Resource> toMarkOn, String docId,
+                                                  BoundingBox boundingBox, Resource system, Double confidence, String uri) {
+        final Resource justification = makeImageJustification(model, docId, boundingBox, system, confidence, uri);
         markJustification(toMarkOn, justification);
         return justification;
     }
@@ -566,8 +672,25 @@ public class AIFUtils {
      */
     public static Resource makeKeyFrameVideoJustification(Model model, String docId, String keyFrame, BoundingBox boundingBox,
                                                           Resource system, Double confidence) {
+        return makeKeyFrameVideoJustification(model, docId, keyFrame, boundingBox, system, confidence, null);
+    }
+
+    /**
+     * Create a justification from something appearing in a key frame of a video.
+     *
+     * @param model       The underlying RDF model for the operation
+     * @param docId       A string containing the document element (child) ID of the source of the justification
+     * @param keyFrame    The String Id of the key frame of the specified video document
+     * @param boundingBox A rectangular box within the key frame that bounds the justification
+     * @param system      The system object for the system which made this justification
+     * @param confidence  The confidence with which to mark the justification
+     * @param uri         A String uri representation of the justification
+     * @return The created video justification resource
+     */
+    public static Resource makeKeyFrameVideoJustification(Model model, String docId, String keyFrame, BoundingBox boundingBox,
+                                                          Resource system, Double confidence, String uri) {
         final Resource justification = makeAIFJustification(model, docId, AidaAnnotationOntology.KEYFRAME_VIDEO_JUSTIFICATION_CLASS,
-                system, confidence);
+                system, confidence, uri);
         justification.addProperty(AidaAnnotationOntology.KEY_FRAME, model.createTypedLiteral(keyFrame));
         markBoundingBox(model, justification, boundingBox);
         return justification;
@@ -588,7 +711,26 @@ public class AIFUtils {
     public static Resource markKeyFrameVideoJustification(Model model, Resource toMarkOn, String docId, String keyFrame,
                                                           BoundingBox boundingBox, Resource system, Double confidence) {
         return markKeyFrameVideoJustification(model, ImmutableSet.of(toMarkOn), docId,
-                keyFrame, boundingBox, system, confidence);
+                keyFrame, boundingBox, system, confidence, null);
+    }
+
+    /**
+     * Mark a justification for something appearing in a key frame of a video.
+     *
+     * @param model       The underlying RDF model for the operation
+     * @param toMarkOn    The Resource to be marked by the specified video document
+     * @param docId       A string containing the document element (child) ID of the source of the justification
+     * @param keyFrame    The String Id of the key frame of the specified video document
+     * @param boundingBox A rectangular box within the key frame that bounds the justification
+     * @param system      The system object for the system which made this justification
+     * @param confidence  The confidence with which to mark the justification
+     * @param uri         A String uri representation of the justification
+     * @return The created video justification resource
+     */
+    public static Resource markKeyFrameVideoJustification(Model model, Resource toMarkOn, String docId, String keyFrame,
+                                                          BoundingBox boundingBox, Resource system, Double confidence, String uri) {
+        return markKeyFrameVideoJustification(model, ImmutableSet.of(toMarkOn), docId,
+                keyFrame, boundingBox, system, confidence, uri);
     }
 
     /**
@@ -605,7 +747,25 @@ public class AIFUtils {
      */
     public static Resource markKeyFrameVideoJustification(Model model, Collection<Resource> toMarkOn, String docId, String keyFrame,
                                                           BoundingBox boundingBox, Resource system, Double confidence) {
-        final Resource justification = makeKeyFrameVideoJustification(model, docId, keyFrame, boundingBox, system, confidence);
+        return markKeyFrameVideoJustification(model, toMarkOn, docId, keyFrame, boundingBox, system, confidence, null);
+    }
+
+    /**
+     * Mark multiple things as being justified by appearing in a key frame of a video.
+     *
+     * @param model       The underlying RDF model for the operation
+     * @param toMarkOn    A Collection of Resources to be marked by the specified video document
+     * @param docId       A string containing the document element (child) ID of the source of the justification
+     * @param keyFrame    The String Id of the key frame of the specified video document
+     * @param boundingBox A rectangular box within the key frame that bounds the justification
+     * @param system      The system object for the system which made this justification
+     * @param confidence  The confidence with which to mark the justification
+     * @param uri         A String uri representation of the justification
+     * @return The created video justification resource
+     */
+    public static Resource markKeyFrameVideoJustification(Model model, Collection<Resource> toMarkOn, String docId, String keyFrame,
+                                                          BoundingBox boundingBox, Resource system, Double confidence, String uri) {
+        final Resource justification = makeKeyFrameVideoJustification(model, docId, keyFrame, boundingBox, system, confidence, uri);
         markJustification(toMarkOn, justification);
         return justification;
     }
@@ -622,8 +782,24 @@ public class AIFUtils {
      */
     public static Resource makeShotVideoJustification(Model model, String docId, String shotId, Resource system,
                                                       Double confidence) {
+        return makeShotVideoJustification(model, docId, shotId, system, confidence, null);
+    }
+
+    /**
+     * Create a justification from something appearing in a video but not in a key frame.
+     *
+     * @param model      The underlying RDF model for the operation
+     * @param docId      A string containing the document element (child) ID of the source of the justification
+     * @param shotId     The String Id of the shot of the specified video document
+     * @param system     The system object for the system which made this justification
+     * @param confidence The confidence with which to mark the justification
+     * @param uri        A String uri representation of the justification
+     * @return The created video justification resource
+     */
+    public static Resource makeShotVideoJustification(Model model, String docId, String shotId, Resource system,
+                                                      Double confidence, String uri) {
         final Resource justification = makeAIFJustification(model, docId, AidaAnnotationOntology.SHOT_VIDEO_JUSTIFICATION_CLASS,
-                system, confidence);
+                system, confidence, uri);
         justification.addProperty(AidaAnnotationOntology.SHOT, model.createTypedLiteral(shotId));
         return justification;
     }
@@ -641,7 +817,24 @@ public class AIFUtils {
      */
     public static Resource markShotVideoJustification(Model model, Resource toMarkOn, String docId, String shotId,
                                                       Resource system, Double confidence) {
-        return markShotVideoJustification(model, ImmutableSet.of(toMarkOn), docId, shotId, system, confidence);
+        return markShotVideoJustification(model, ImmutableSet.of(toMarkOn), docId, shotId, system, confidence, null);
+    }
+
+    /**
+     * Mark a justification for something appearing in a video but not in a key frame.
+     *
+     * @param model      The underlying RDF model for the operation
+     * @param toMarkOn   A Resource to be marked by the specified video document
+     * @param docId      A string containing the document element (child) ID of the source of the justification
+     * @param shotId     The String Id of the shot of the specified video document
+     * @param system     The system object for the system which made this justification
+     * @param confidence The confidence with which to mark the justification
+     * @param uri        A String uri representation of the justification
+     * @return The created video justification resource
+     */
+    public static Resource markShotVideoJustification(Model model, Resource toMarkOn, String docId, String shotId,
+                                                      Resource system, Double confidence, String uri) {
+        return markShotVideoJustification(model, ImmutableSet.of(toMarkOn), docId, shotId, system, confidence, uri);
     }
 
     /**
@@ -657,7 +850,24 @@ public class AIFUtils {
      */
     public static Resource markShotVideoJustification(Model model, Collection<Resource> toMarkOn, String docId, String shotId,
                                                       Resource system, Double confidence) {
-        final Resource justification = makeShotVideoJustification(model, docId, shotId, system, confidence);
+        return markShotVideoJustification(model, toMarkOn, docId, shotId, system, confidence, null);
+    }
+
+    /**
+     * Mark multiple things as being justified by appearing in a video but not in a key frame.
+     *
+     * @param model      The underlying RDF model for the operation
+     * @param toMarkOn   A Collection of Resources to be marked by the specified video document
+     * @param docId      A string containing the document element (child) ID of the source of the justification
+     * @param shotId     The String Id of the shot of the specified video document
+     * @param system     The system object for the system which made this justification
+     * @param confidence The confidence with which to mark the justification
+     * @param uri        A String uri representation of the justification
+     * @return The created video justification resource
+     */
+    public static Resource markShotVideoJustification(Model model, Collection<Resource> toMarkOn, String docId, String shotId,
+                                                      Resource system, Double confidence, String uri) {
+        final Resource justification = makeShotVideoJustification(model, docId, shotId, system, confidence, uri);
         markJustification(toMarkOn, justification);
         return justification;
     }
@@ -675,12 +885,29 @@ public class AIFUtils {
      */
     public static Resource makeAudioJustification(Model model, String docId, Double startTimestamp, Double endTimestamp,
                                                   Resource system, Double confidence) {
+        return makeAudioJustification(model, docId, startTimestamp, endTimestamp, system, confidence, null);
+    }
+
+    /**
+     * Make an audio justification.
+     *
+     * @param model          The underlying RDF model for the operation
+     * @param docId          A string containing the document element (child) ID of the source of the justification
+     * @param startTimestamp A timestamp within the audio document where the justification starts
+     * @param endTimestamp   A timestamp within the audio document where the justification ends
+     * @param system         The system object for the system which made this justification
+     * @param confidence     The confidence with which to mark the justification
+     * @param uri            A String uri representation of the justification
+     * @return The created audio justification resource
+     */
+    public static Resource makeAudioJustification(Model model, String docId, Double startTimestamp, Double endTimestamp,
+                                                  Resource system, Double confidence, String uri) {
         if (endTimestamp <= startTimestamp) {
             throw new IllegalArgumentException("End timestamp " + endTimestamp
-                    + "does not follow start timestamp " + startTimestamp);
+                    + " does not follow start timestamp " + startTimestamp);
         }
         final Resource justification = makeAIFJustification(model, docId, AidaAnnotationOntology.AUDIO_JUSTIFICATION_CLASS,
-                system, confidence);
+                system, confidence, uri);
 
         justification.addProperty(AidaAnnotationOntology.START_TIMESTAMP,
                 model.createTypedLiteral(startTimestamp));
@@ -706,7 +933,27 @@ public class AIFUtils {
                                                   Double startTimestamp, Double endTimestamp,
                                                   Resource system, Double confidence) {
         return markAudioJustification(model, ImmutableSet.of(toMarkOn), docId,
-                startTimestamp, endTimestamp, system, confidence);
+                startTimestamp, endTimestamp, system, confidence, null);
+    }
+
+    /**
+     * Mark something as being justified by a particular audio document.
+     *
+     * @param model          The underlying RDF model for the operation
+     * @param toMarkOn       A Resource to be marked by the specified audio document
+     * @param docId          A string containing the document element (child) ID of the source of the justification
+     * @param startTimestamp A timestamp within the audio document where the justification starts
+     * @param endTimestamp   A timestamp within the audio document where the justification ends
+     * @param system         The system object for the system which made this justification
+     * @param confidence     The confidence with which to mark the justification
+     * @param uri            A String uri representation of the justification
+     * @return The created audio justification resource
+     */
+    public static Resource markAudioJustification(Model model, Resource toMarkOn, String docId,
+                                                  Double startTimestamp, Double endTimestamp,
+                                                  Resource system, Double confidence, String uri) {
+        return markAudioJustification(model, ImmutableSet.of(toMarkOn), docId,
+                startTimestamp, endTimestamp, system, confidence, uri);
     }
 
     /**
@@ -724,7 +971,26 @@ public class AIFUtils {
     public static Resource markAudioJustification(Model model, Collection<Resource> toMarkOn, String docId,
                                                   Double startTimestamp, Double endTimestamp,
                                                   Resource system, Double confidence) {
-        final Resource justification = makeAudioJustification(model, docId, startTimestamp, endTimestamp, system, confidence);
+        return markAudioJustification(model, toMarkOn, docId, startTimestamp, endTimestamp, system, confidence, null);
+    }
+
+    /**
+     * Mark multiple things as being justified by appearing in an audio document.
+     *
+     * @param model          The underlying RDF model for the operation
+     * @param toMarkOn       A Collection of Resources to be marked by the specified audio document
+     * @param docId          A string containing the document element (child) ID of the source of the justification
+     * @param startTimestamp A timestamp within the audio document where the justification starts
+     * @param endTimestamp   A timestamp within the audio document where the justification ends
+     * @param system         The system object for the system which made this justification
+     * @param confidence     The confidence with which to mark the justification
+     * @param uri            A String uri representation of the justification
+     * @return The created audio justification resource
+     */
+    public static Resource markAudioJustification(Model model, Collection<Resource> toMarkOn, String docId,
+                                                  Double startTimestamp, Double endTimestamp,
+                                                  Resource system, Double confidence, String uri) {
+        final Resource justification = makeAudioJustification(model, docId, startTimestamp, endTimestamp, system, confidence, uri);
         markJustification(toMarkOn, justification);
         return justification;
     }
@@ -889,7 +1155,24 @@ public class AIFUtils {
     public static Resource markAsPossibleClusterMember(Model model, Resource possibleClusterMember,
                                                        Resource cluster, Double confidence,
                                                        Resource system) {
-        final Resource clusterMemberAssertion = makeAIFResource(model, null,
+        return markAsPossibleClusterMember(model, possibleClusterMember, cluster, confidence, system, null);
+    }
+
+    /**
+     * Mark an entity or event as a possible member of a cluster.
+     *
+     * @param model                 The underlying RDF model for the operation
+     * @param possibleClusterMember The entity or event to mark as a possible member of the specified cluster
+     * @param cluster               The cluster to associate with the possible cluster member
+     * @param confidence            The confidence with which to mark the cluster membership
+     * @param system                The system object for the system which marked the specified cluster
+     * @param uri                   A string URI representation of the cluster member
+     * @return The created cluster membership assertion
+     */
+    public static Resource markAsPossibleClusterMember(Model model, Resource possibleClusterMember,
+                                                       Resource cluster, Double confidence,
+                                                       Resource system, String uri) {
+        final Resource clusterMemberAssertion = makeAIFResource(model, uri,
                 AidaAnnotationOntology.CLUSTER_MEMBERSHIP_CLASS, system);
         clusterMemberAssertion.addProperty(AidaAnnotationOntology.CLUSTER_PROPERTY, cluster);
         clusterMemberAssertion.addProperty(AidaAnnotationOntology.CLUSTER_MEMBER, possibleClusterMember);
@@ -1125,7 +1408,8 @@ public class AIFUtils {
      * This inner class encapsulates the LDC representation of time.
      */
     public static final class LDCTimeComponent {
-        public enum LDCTimeType { ON, BEFORE, AFTER, UNKNOWN }
+        public enum LDCTimeType {ON, BEFORE, AFTER, UNKNOWN}
+
         private static final String dateDelimiter = "-";
 
         private final LDCTimeType type;
@@ -1158,6 +1442,7 @@ public class AIFUtils {
 
         /**
          * Create an LDCTimeComponent from a type and a date
+         *
          * @param type {@link String} representation of {@link LDCTimeType}
          * @param date {@link String} containing date to be parsed. Expects yyyy-mm-dd where y, m, and d can be replaced with 'X'
          * @return new {@link LDCTimeComponent} object
@@ -1199,8 +1484,12 @@ public class AIFUtils {
      */
     public static Resource markLDCTime(Model model, Resource toMark, LDCTimeComponent start, LDCTimeComponent end, Resource system) {
         final Resource ldcTime = makeAIFResource(model, null, AidaAnnotationOntology.LDC_TIME_CLASS, system);
-        ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_START, start.makeAIFTimeComponent(model));
-        ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_END, end.makeAIFTimeComponent(model));
+        if (start != null) {
+            ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_START, start.makeAIFTimeComponent(model));
+        }
+        if (end != null) {
+            ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_END, end.makeAIFTimeComponent(model));
+        }
 
         toMark.addProperty(AidaAnnotationOntology.LDC_TIME_PROPERTY, ldcTime);
         return ldcTime;

--- a/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1062,6 +1062,144 @@ public class ExamplesAndValidationTest {
 
             utils.testValid("create an event with LDCTime");
         }
+
+        /**
+         * Create justifications and cluster memberships with and without optional URIs.
+         * Without a URI, justifications and cluster memberships will be blank nodes.
+         */
+        @Nested
+        class testOptionalURIs {
+            private int uriCount;
+            private double confidence;
+            private BoundingBox boundingBox;
+            private Resource person1;
+            private Resource person2;
+            private ImmutableSet<Resource> personCollection;
+            private ImmutableSet<Resource> gpeCollection;
+
+            @BeforeEach
+            void setup() {
+                uriCount = 0;
+                confidence = 1.0;
+                boundingBox = new BoundingBox(new Point(123, 45), new Point(167, 98));
+
+                person1 = utils.makeValidAIFEntity(SeedlingOntology.Person);
+                person2 = utils.makeValidAIFEntity(SeedlingOntology.Person);
+                personCollection = ImmutableSet.of(person1, person2);
+
+                gpeCollection = ImmutableSet.of(utils.makeValidAIFEntity(SeedlingOntology.GeopoliticalEntity),
+                        utils.makeValidAIFEntity(SeedlingOntology.GeopoliticalEntity));
+            }
+
+            /**
+             * Create text justifications with and without optional URIs.  Without a URI, a blank node is created.
+             */
+            @Test
+            void textJustification() {
+                final int startOffset = 2;
+                final int endOffsetInclusive = 4;
+
+                makeTextJustification(model, utils.getDocumentName(), startOffset, endOffsetInclusive, system, confidence);
+                makeTextJustification(model, utils.getDocumentName(), startOffset*2, endOffsetInclusive*2, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markTextJustification(model, person1, utils.getDocumentName(), startOffset*3, endOffsetInclusive*3, system, confidence);
+                markTextJustification(model, person2, utils.getDocumentName(), startOffset*4, endOffsetInclusive*4, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markTextJustification(model, personCollection, utils.getDocumentName(), startOffset*5, endOffsetInclusive*5, system, confidence);
+                markTextJustification(model, gpeCollection, utils.getDocumentName(), startOffset*6, endOffsetInclusive*6, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+
+                utils.testValid("textJustification with and without optional URI argument");
+            }
+
+            /**
+             * Create image justifications with and without optional URIs.  Without a URI, a blank node is created.
+             */
+            @Test
+            void imageJustification() {
+                makeImageJustification(model, utils.getDocumentName(), boundingBox, system, confidence);
+                makeImageJustification(model, utils.getDocumentName(), boundingBox, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markImageJustification(model, person1, utils.getDocumentName(), boundingBox, system, confidence);
+                markImageJustification(model, person2, utils.getDocumentName(), boundingBox, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markImageJustification(model, personCollection, utils.getDocumentName(), boundingBox, system, confidence);
+                markImageJustification(model, gpeCollection, utils.getDocumentName(), boundingBox, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+
+                utils.testValid("imageJustification with and without optional URI argument");
+            }
+
+            /**
+             * Create keyFrame justifications with and without optional URIs.  Without a URI, a blank node is created.
+             */
+            @Test
+            void keyFrameJustification() {
+                final String keyFrame = "Keyframe ID#";
+
+                makeKeyFrameVideoJustification(model, utils.getDocumentName(), keyFrame+1, boundingBox, system, confidence);
+                makeKeyFrameVideoJustification(model, utils.getDocumentName(), keyFrame+2, boundingBox, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markKeyFrameVideoJustification(model, person1, utils.getDocumentName(), keyFrame+3, boundingBox, system, confidence);
+                markKeyFrameVideoJustification(model, person2, utils.getDocumentName(), keyFrame+4, boundingBox, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markKeyFrameVideoJustification(model, personCollection, utils.getDocumentName(), keyFrame+5, boundingBox, system, confidence);
+                markKeyFrameVideoJustification(model, gpeCollection, utils.getDocumentName(), keyFrame+6, boundingBox, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+
+                utils.testValid("keyFrameJustification with and without optional URI argument");
+            }
+
+            /**
+             * Create shot justifications with and without optional URIs.  Without a URI, a blank node is created.
+             */
+            @Test
+            void shotJustification() {
+                final String shotId = "Shot ID#";
+
+                makeShotVideoJustification(model, utils.getDocumentName(), shotId+1, system, confidence);
+                makeShotVideoJustification(model, utils.getDocumentName(), shotId+2, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markShotVideoJustification(model, person1, utils.getDocumentName(), shotId+3, system, confidence);
+                markShotVideoJustification(model, person2, utils.getDocumentName(), shotId+4, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markShotVideoJustification(model, personCollection, utils.getDocumentName(), shotId+5, system, confidence);
+                markShotVideoJustification(model, gpeCollection, utils.getDocumentName(), shotId+6, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+
+                utils.testValid("shotJustification with and without optional URI argument");
+            }
+
+            /**
+             * Create audio justifications with and without optional URIs.  Without a URI, a blank node is created.
+             */
+            @Test
+            void audioJustification() {
+                final Double startTimestamp = 5.0;
+                final Double endTimestamp = 10.0;
+
+                makeAudioJustification(model, utils.getDocumentName(), startTimestamp, endTimestamp, system, confidence);
+                makeAudioJustification(model, utils.getDocumentName(), startTimestamp*1.1, endTimestamp*1.1, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markAudioJustification(model, person1, utils.getDocumentName(), startTimestamp*1.2, endTimestamp*1.2, system, confidence);
+                markAudioJustification(model, person2, utils.getDocumentName(), startTimestamp*1.3, endTimestamp*1.3, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+                markAudioJustification(model, personCollection, utils.getDocumentName(), startTimestamp*1.4, endTimestamp*1.4, system, confidence);
+                markAudioJustification(model, gpeCollection, utils.getDocumentName(), startTimestamp*1.5, endTimestamp*1.5, system, confidence, utils.getUri("custom-uri-" + ++uriCount));
+
+                utils.testValid("audioJustification with and without optional URI argument");
+            }
+
+            /**
+             * Create cluster memberships with and without optional URIs.  Without a URI, a blank node is created.
+             */
+            @Test
+            void possibleClusterMember() {
+                // Two people, probably the same person
+                final Resource putin = makeEntity(model, putinDocumentEntityUri, system);
+                markType(model, utils.getAssertionUri(), putin, SeedlingOntology.Person, system, 1.0);
+                markName(putin, "Путин");
+
+                final Resource vladimirPutin = makeEntity(model, utils.getUri("E780885.00311"), system);
+                markType(model, utils.getAssertionUri(), vladimirPutin, SeedlingOntology.Person, system, 1.0);
+                markName(vladimirPutin, "Vladimir Putin");
+
+                // create a cluster with prototype
+                final Resource putinCluster = makeClusterWithPrototype(model, utils.getClusterUri(), putin, system);
+
+                // person 1 is definitely in the cluster, person 2 is probably in the cluster
+                markAsPossibleClusterMember(model, putin, putinCluster, 1.0, system);
+                markAsPossibleClusterMember(model, vladimirPutin, putinCluster, 0.71, system, utils.getUri("clusterMembershipURI"));
+
+                utils.testValid("possibleClusterMember with and without optional URI argument");
+            }
+        }
     }
 
 


### PR DESCRIPTION
Incorporated AIDA-893 (optional URIs to certain API) into v1.0.x release.

You may find it useful to compare with [AIDA-893 changed files](https://github.com/NextCenturyCorporation/AIDA-Interchange-Format/pull/249/files) to see how the changes were incorporated.

Note I also incorporated a small fix to `AIFUtils.markLDCTime()` that was made as part of AIDA-795 (multithreaded validator).