### PR TITLE
Bump to 1.1.0-SNAPSHOT

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -29,22 +29,4 @@ added.
 
 ### How do I migrate from the GAIA/Kotlin version of AIF to the Java version?
 
-First, if you haven't already, you'll need to change your build script or tool to import
-`aida-interchange-1.0.4.jar` (changed from `gaia-interchange-kotlin-1.0-SNAPSHOT.jar`).
-For gradle, for example, include the following in the dependencies in your `build.gradle` file:
-
-`dependencies {
-    compile 'com.ncc:aida-interchange:1.0.4'
-}`
-
-Next, update any source files that import the `edu.isi.gaia` package to use the `com.ncc.aif` package instead.
-For example, change:
-```
-import edu.isi.gaia.AIFUtils;
-```
-to
-```
-import com.ncc.aif.AIFUtils;
-```
-You may also wish to clean out any vestiges of the Kotlin version (class files, libraries) from build
-tool caches (e.g., the `edu/isi/gaia-interchange-kotlin/` directory in Maven's repository).
+See the [FAQ for release AIF v1.0.4](https://github.com/NextCenturyCorporation/AIDA-Interchange-Format/blob/tag/v1.0.4/FAQ.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains resources to support the AIDA Interchange Format (AIF).
 
 *    utilities to make it easier to work with this format.  Java utilities are
      in `java/src/main/java/com/ncc/aif/AIFUtils.java`, which can be used by adding
-     a Maven dependency on `com.ncc:aida-interchange:1.0.4`.  A
+     a Maven dependency on `com.ncc:aida-interchange:1.1.0-SNAPSHOT`.  A
      Python translation of these utilities is in
      `python/aida_interchange/aifutils.py`.
 

--- a/java/README.md
+++ b/java/README.md
@@ -11,7 +11,7 @@ installation above into your build script or tool.  For gradle, for
 example, include the following in the dependencies in your `build.gradle` file:
 
 `dependencies {
-    compile 'com.ncc:aida-interchange:1.0.4'
+    compile 'com.ncc:aida-interchange:1.1.0-SNAPSHOT'
 }`
 
 In your code, import classes from the `com.ncc.aif` package.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ncc</groupId>
     <artifactId>aida-interchange</artifactId>
-    <version>1.0.4</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>AIDA-Interchange-Format</name>
     <description>Library containing resources to support the AIDA Interchange Format (AIF)</description>

--- a/python/aida_interchange/aifutils.py
+++ b/python/aida_interchange/aifutils.py
@@ -569,7 +569,7 @@ def mark_shot_video_justification(g, things_to_justify, doc_id, shot_id, system,
     :param str shot_id: The string Id of the shot of the specified video document
     :param str doc_id: A string containing the document element (child) ID of the
         source of the justification
-    :param rdflib.term.URIRef system: The system object for the system which made 
+    :param rdflib.term.URIRef system: The system object for the system which made
         this justification
     :param float confidence: The confidence with which to mark the justification
     :param str uri_ref: A string URI representation of the video justification (Default is None)

--- a/python/aida_interchange/ldc_time_component.py
+++ b/python/aida_interchange/ldc_time_component.py
@@ -52,4 +52,3 @@ class LDCTimeComponent:
         self.add_literal(g, time_component, AIDA_ANNOTATION.month, self.month, XSD.gMonth)
         self.add_literal(g, time_component, AIDA_ANNOTATION.day, self.day, XSD.gDay)
         return time_component
-        

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='aida-interchange',
-      version='1.0.4',
+      version='1.1.0',
       author='Ryan Gabbard',
       author_email='gabbard@isi.edu',
       description='AIDA Interchange Format tools',


### PR DESCRIPTION
Bump master to 1.1.0-SNAPSHOT.  Other changes include:
- Make FAQ.md reference v1.0.4 for Kotlin upgrade
- Fix minor spacing differences between master and tag/v1.0.4