### PR TITLE
minor space differences between master and tag/v1.0.4

### DIFF
--- a/python/aida_interchange/aifutils.py
+++ b/python/aida_interchange/aifutils.py
@@ -569,7 +569,7 @@ def mark_shot_video_justification(g, things_to_justify, doc_id, shot_id, system,
     :param str shot_id: The string Id of the shot of the specified video document
     :param str doc_id: A string containing the document element (child) ID of the
         source of the justification
-    :param rdflib.term.URIRef system: The system object for the system which made 
+    :param rdflib.term.URIRef system: The system object for the system which made
         this justification
     :param float confidence: The confidence with which to mark the justification
     :param str uri_ref: A string URI representation of the video justification (Default is None)

--- a/python/aida_interchange/ldc_time_component.py
+++ b/python/aida_interchange/ldc_time_component.py
@@ -52,4 +52,3 @@ class LDCTimeComponent:
         self.add_literal(g, time_component, AIDA_ANNOTATION.month, self.month, XSD.gMonth)
         self.add_literal(g, time_component, AIDA_ANNOTATION.day, self.day, XSD.gDay)
         return time_component
-        


### PR DESCRIPTION
There were minor space differences that didn't get back into master.
$ git checkout develop
$ git diff tag/v1.0.4
- see no differences

$ git diff master
- see minor space differences

This PR updates master to match v1.0.4