### PR TITLE
AIDA-1114 Hotfix

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -30,11 +30,11 @@ added.
 ### How do I migrate from the GAIA/Kotlin version of AIF to the Java version?
 
 First, if you haven't already, you'll need to change your build script or tool to import
-`aida-interchange-1.0.4.jar` (changed from `gaia-interchange-kotlin-1.0-SNAPSHOT.jar`).
+`aida-interchange-1.0.5.jar` (changed from `gaia-interchange-kotlin-1.0-SNAPSHOT.jar`).
 For gradle, for example, include the following in the dependencies in your `build.gradle` file:
 
 `dependencies {
-    compile 'com.ncc:aida-interchange:1.0.4'
+    compile 'com.ncc:aida-interchange:1.0.5'
 }`
 
 Next, update any source files that import the `edu.isi.gaia` package to use the `com.ncc.aif` package instead.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains resources to support the AIDA Interchange Format (AIF).
 
 *    utilities to make it easier to work with this format.  Java utilities are
      in `java/src/main/java/com/ncc/aif/AIFUtils.java`, which can be used by adding
-     a Maven dependency on `com.ncc:aida-interchange:1.0.4`.  A
+     a Maven dependency on `com.ncc:aida-interchange:1.0.5`.  A
      Python translation of these utilities is in
      `python/aida_interchange/aifutils.py`.
 

--- a/java/README.md
+++ b/java/README.md
@@ -11,7 +11,7 @@ installation above into your build script or tool.  For gradle, for
 example, include the following in the dependencies in your `build.gradle` file:
 
 `dependencies {
-    compile 'com.ncc:aida-interchange:1.0.4'
+    compile 'com.ncc:aida-interchange:1.0.5'
 }`
 
 In your code, import classes from the `com.ncc.aif` package.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ncc</groupId>
     <artifactId>aida-interchange</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
     <name>AIDA-Interchange-Format</name>
     <description>Library containing resources to support the AIDA Interchange Format (AIF)</description>
@@ -88,19 +88,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- for SHACL validation -->

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='aida-interchange',
-      version='1.0.4',
+      version='1.0.5',
       author='Ryan Gabbard',
       author_email='gabbard@isi.edu',
       description='AIDA Interchange Format tools',


### PR DESCRIPTION
- Upgraded the com.fasterxml.jackson libraries to version 2.10.0 to address potential vulnerability.
- Changed AIF version to 1.0.5 in both Java and Python versions
- Updated all documentation to point to AIF 1.0.5

**After this gets merged into master we will need to tag it as release 1.0.5**
