### PR TITLE
Aida 525: Update AIF to Java 11

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -21,6 +21,8 @@ asserts the hypothesis that relations 1, 2, and 3 are all true.
 An example of constructing two distinct hypotheses is given
 in the `twoSeedlingHypotheses` test in `src/test/java/com/ncc/aif/ExamplesAndValidationTest.java`.
 
+TEST TEST REMOVE
+
 Currently a hypothesis cannot express disjunctions (e.g. "relation 1 holds true and either
 relation 2 or relation 3") since we assume that such cases should expressed as two (or more)
 distinct hypotheses (e.g. one hypothesis for "relation 1 and relation 2" and another for

--- a/FAQ.md
+++ b/FAQ.md
@@ -21,8 +21,6 @@ asserts the hypothesis that relations 1, 2, and 3 are all true.
 An example of constructing two distinct hypotheses is given
 in the `twoSeedlingHypotheses` test in `src/test/java/com/ncc/aif/ExamplesAndValidationTest.java`.
 
-TEST TEST REMOVE
-
 Currently a hypothesis cannot express disjunctions (e.g. "relation 1 holds true and either
 relation 2 or relation 3") since we assume that such cases should expressed as two (or more)
 distinct hypotheses (e.g. one hypothesis for "relation 1 and relation 2" and another for

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -50,6 +50,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <junit.jupiter.version>5.5.2</junit.jupiter.version>
     </properties>
 
     <!--
@@ -80,7 +81,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.1-jre</version>
+            <version>28.1-jre</version>
         </dependency>
 
         <!-- For serializing JSON into privateData -->
@@ -88,19 +89,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- for SHACL validation -->
@@ -121,34 +122,42 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.1.0</version>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+     <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
+    </dependency>
+   </dependencies>
 
     <build>
         <plugins>
             <!-- to compile Java code -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <release>8</release>
-                    <!-- ErrorProne disabled until https://github.com/google/error-prone/pull/1344 is merged and released -->
-                    <!--
-                    <compilerArgs>
-                        <arg>-Xplugin:ErrorProne</arg>
-                        <arg>-XDcompilePolicy=byfile</arg>
-                    </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.3.3</version>
-                        </path>
-                    </annotationProcessorPaths>
-                    -->
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.8.1</version>
+              <configuration>
+                <release>12</release>
+                <compilerArgs>
+                  <!-- ErrorProne disabled until https://github.com/google/error-prone/pull/1344 is merged and released -->
+                  <!--
+                  <arg>-Xplugin:ErrorProne</arg>
+                  <arg>-XDcompilePolicy=byfile</arg>
+                  -->
+                </compilerArgs>
+                <!--
+                <annotationProcessorPaths>
+                  <path>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_core</artifactId>
+                    <version>2.3.3</version>
+                  </path>
+                </annotationProcessorPaths>
+                -->
                 </configuration>
             </plugin>
             <!-- to add source code to jar -->
@@ -169,7 +178,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.1.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -186,21 +195,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.2.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.2.0</version>
-                    </dependency>
-                </dependencies>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.22.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <version>2.22.2</version>
             </plugin>
             <!-- to capture version -->
             <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -141,9 +141,9 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>3.8.1</version>
               <configuration>
-                <release>12</release>
+                <release>11</release>
                 <compilerArgs>
-                  <!-- ErrorProne disabled until https://github.com/google/error-prone/pull/1344 is merged and released -->
+                  <!-- ErrorProne disabled until https://github.com/google/error-prone/issues/1158 (and 1157) are addressed and released -->
                   <!--
                   <arg>-Xplugin:ErrorProne</arg>
                   <arg>-XDcompilePolicy=byfile</arg>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -134,31 +134,22 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <compilerId>javac-with-errorprone</compilerId>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <!-- maven-compiler-plugin defaults to targeting Java 1.6, but AIDA
-                         targets 1.8. -->
-                    <source>8</source>
-                    <target>8</target>
-                    <!-- Prevents an endPosTable exception during compilation
-                    when using code generation - this is a bug in Java, see
-                    https://bugs.openjdk.java.net/browse/JDK-8062800 -->
-                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                    <release>8</release>
+                    <!-- ErrorProne disabled until https://github.com/google/error-prone/pull/1344 is merged and released -->
+                    <!--
+                    <compilerArgs>
+                        <arg>-Xplugin:ErrorProne</arg>
+                        <arg>-XDcompilePolicy=byfile</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.3.3</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    -->
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8</version>
-                    </dependency>
-                    <!-- override plexus-compiler-javac-errorprone's dependency on
-                         Error Prone with the latest version -->
-                    <dependency>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_core</artifactId>
-                        <version>2.1.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <!-- to add source code to jar -->
             <plugin>


### PR DESCRIPTION
**NOTE: This PR should not be merged into `develop` until [AIDA-930 / PR#305](https://github.com/NextCenturyCorporation/VERDI/pull/305) (Upgrade VERDI to later Java version) is approved.**

Background, process, and discussion of updating dependencies are all documented in the [Upgrading Java in AIDA](https://nextcentury.atlassian.net/wiki/spaces/AIDA/pages/628228337/Upgrading+Java+in+AIDA) Confluence page.

Also note that the build currently targets release 11 (JDK 11).  The AIDA Architecture Working Group meeting suggested that people didn't have a problem with us requiring a post-JDK8 version of Java.