### PR TITLE
Aida 1158

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Usage:  <br>
 |`--ont=FILE ...` | validate against the OWL-formatted ontolog(ies) at the specified filename(s) |
 |`--nist` | validate against the NIST restrictions |
 |`--nist-ta3` | validate against the NIST hypothesis restrictions (implies `--nist`) |
-|`--hypothesis-max-size=num` | Specify the maximum size of a hypothesis file in MB when validating against the NIST hypothesis restrictions (`--nist-ta3`). Default is 5 |
+|`--hypothesis-max-size=<hypothesisMaxSize>` | Specify the maximum size of a hypothesis file in MB when validating against the NIST hypothesis restrictions (`--nist-ta3`). Default is 5 |
 |`--abort[=num]` | Abort validation after `[num]` SHACL violations (num > 2), or three violations if `[num]` is omitted. |
 |`--depth[=num]` | Perform shallow validation in which each SHACL rule (shape) is only applied to `[num]` target nodes, or 50 nodes if `[num]` is omitted (requires -t). |
 |`--pm` | Enable progress monitor that shows ongoing validation progress.  If `-t` is specified, then thread metrics are provided post-validation instead. |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Usage:  <br>
 |`--ont=FILE ...` | validate against the OWL-formatted ontolog(ies) at the specified filename(s) |
 |`--nist` | validate against the NIST restrictions |
 |`--nist-ta3` | validate against the NIST hypothesis restrictions (implies `--nist`) |
+|`--hypothesis-max-size=num` | Specify the maximum size of a hypothesis file in MB when validating against the NIST hypothesis restrictions (`--nist-ta3`). Default is 5 |
 |`--abort[=num]` | Abort validation after `[num]` SHACL violations (num > 2), or three violations if `[num]` is omitted. |
 |`--depth[=num]` | Perform shallow validation in which each SHACL rule (shape) is only applied to `[num]` target nodes, or 50 nodes if `[num]` is omitted (requires -t). |
 |`--pm` | Enable progress monitor that shows ongoing validation progress.  If `-t` is specified, then thread metrics are provided post-validation instead. |

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -110,6 +110,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     @Option(names = "--nist", description = "Validate against the NIST restrictions")
     private boolean useNISTRestriction;
 
+    //TODO: When picocli 4.0 is stable, make this an ArgGroup to enforce mutual exclusivity
     @Option(names = "--nist-ta3", description = "Validate against the NIST hypothesis restrictions (implies --nist)")
     private boolean useNISTTA3Rescriction;
 

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -149,7 +149,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     private int depth = Integer.MIN_VALUE; // Don't perform shallow validation by default
 
     private static class DepthConverter implements CommandLine.ITypeConverter<Integer> {
-        @Overridegit
+        @Override
         public Integer convert(String value) {
             try {
                 return "".equals(value) ? DEFAULT_DEPTH : Integer.parseInt(value);

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -114,7 +114,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     private boolean useNISTTA3Rescriction;
 
     @Option(names = "--hypothesis-max-size", defaultValue = "5", description = "The maximum size of a hypothesis file in MB, default is 5",
-            converter = HypothesisMaxSizeConverter.class)
+            arity = "1", converter = HypothesisMaxSizeConverter.class)
     private int hypothesisMaxSize;
 
     private static class HypothesisMaxSizeConverter implements CommandLine.ITypeConverter<Integer> {

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -113,7 +113,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     @Option(names = "--nist-ta3", description = "Validate against the NIST hypothesis restrictions (implies --nist)")
     private boolean useNISTTA3Rescriction;
 
-    @Option(names = "--hypothesis-max-size", defaultValue = "5", description = "The maximum size of a hypothesis file in MB, default is 5MB",
+    @Option(names = "--hypothesis-max-size", defaultValue = "5", description = "The maximum size of a hypothesis file in MB, default is 5",
             converter = HypothesisMaxSizeConverter.class)
     private int hypothesisMaxSize;
 

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -83,6 +83,9 @@ public class ValidateAIFCli implements Callable<Integer> {
     private static final int DEFAULT_DEPTH = 50;
     private static final int MINIMUM_DEPTH = 1;
 
+    //Hypothesis
+    private static final String DEAFULT_HYPOTHESIS_SIZE = "5"; //MB
+
     // Profiling
     private static final int LONG_QUERY_THRESH = 2000;
     // Threading
@@ -114,7 +117,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     @Option(names = "--nist-ta3", description = "Validate against the NIST hypothesis restrictions (implies --nist)")
     private boolean useNISTTA3Rescriction;
 
-    @Option(names = "--hypothesis-max-size", defaultValue = "5", description = "The maximum size of a hypothesis file in MB, default is 5",
+    @Option(names = "--hypothesis-max-size", defaultValue = DEAFULT_HYPOTHESIS_SIZE, description = "The maximum size of a hypothesis file in MB, default is 5",
             arity = "1", converter = HypothesisMaxSizeConverter.class)
     private int hypothesisMaxSize;
 
@@ -122,9 +125,14 @@ public class ValidateAIFCli implements Callable<Integer> {
         @Override
         public Integer convert(String value) {
             try {
-                return "".equals(value) ? DEFAULT_DEPTH : Integer.parseInt(value);
+                Integer size = "".equals(value) ? Integer.valueOf(DEAFULT_HYPOTHESIS_SIZE) : Integer.parseInt(value);
+
+                if (size < 0 ) {
+                    throw new IllegalArgumentException();
+                }
+                return size;
             } catch (Exception ex) {
-                throw new CommandLine.TypeConversionException(String.format(ERR_BAD_ARGTYPE, value, Integer.TYPE.getSimpleName()));
+                throw new CommandLine.TypeConversionException(String.format(ERR_BAD_ARGTYPE, value, "positive integer"));
             }
         }
     }

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -84,7 +84,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     private static final int MINIMUM_DEPTH = 1;
 
     //Hypothesis
-    private static final String DEAFULT_HYPOTHESIS_SIZE = "5"; //MB
+    private static final String DEFAULT_HYPOTHESIS_SIZE = "5"; //MB
 
     // Profiling
     private static final int LONG_QUERY_THRESH = 2000;
@@ -117,7 +117,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     @Option(names = "--nist-ta3", description = "Validate against the NIST hypothesis restrictions (implies --nist)")
     private boolean useNISTTA3Rescriction;
 
-    @Option(names = "--hypothesis-max-size", defaultValue = DEAFULT_HYPOTHESIS_SIZE, description = "The maximum size of a hypothesis file in MB, default is 5",
+    @Option(names = "--hypothesis-max-size", defaultValue = DEFAULT_HYPOTHESIS_SIZE, description = "The maximum size of a hypothesis file in MB, default is 5",
             arity = "1", converter = HypothesisMaxSizeConverter.class)
     private int hypothesisMaxSize;
 
@@ -125,7 +125,7 @@ public class ValidateAIFCli implements Callable<Integer> {
         @Override
         public Integer convert(String value) {
             try {
-                Integer size = "".equals(value) ? Integer.valueOf(DEAFULT_HYPOTHESIS_SIZE) : Integer.parseInt(value);
+                Integer size = "".equals(value) ? Integer.parseInt(DEFAULT_HYPOTHESIS_SIZE) : Integer.parseInt(value);
 
                 if (size < 0 ) {
                     throw new IllegalArgumentException();

--- a/java/src/test/java/com/ncc/aif/ValidateCLITest.java
+++ b/java/src/test/java/com/ncc/aif/ValidateCLITest.java
@@ -146,6 +146,11 @@ public class ValidateCLITest {
                     "--ldc", "--hypothesis-max-size", "s", "-t", "2", "-f", "tmp.ttl");
         }
         @Test
+        void hypothesisMaxSizeNegative() {
+            expectUsageError(ValidateAIFCli.ERR_BAD_ARGTYPE.replaceAll("%.", ""),
+                    "--ldc", "--hypothesis-max-size", "s", "-10", "2", "-f", "tmp.ttl");
+        }
+        @Test
         void hypothesisMaxSizeValid() {
             expectCorrect("--ldc", "--hypothesis-max-size", "10", "-t=2", "-f", "tmp.ttl");
         }

--- a/java/src/test/java/com/ncc/aif/ValidateCLITest.java
+++ b/java/src/test/java/com/ncc/aif/ValidateCLITest.java
@@ -139,6 +139,19 @@ public class ValidateCLITest {
     }
 
     @Nested
+    class HypothesisMaxSizeArgument {
+        @Test
+        void hypothesisMaxSizeBadType() {
+            expectUsageError(ValidateAIFCli.ERR_BAD_ARGTYPE.replaceAll("%.", ""),
+                    "--ldc", "--hypothesis-max-size", "s", "-t", "2", "-f", "tmp.ttl");
+        }
+        @Test
+        void hypothesisMaxSizeValid() {
+            expectCorrect("--ldc", "--hypothesis-max-size", "10", "-t=2", "-f", "tmp.ttl");
+        }
+    }
+
+    @Nested
     class ThreadArgument {
         @Test
         void threadsTooLow() {

--- a/java/src/test/java/com/ncc/aif/ValidateCLITest.java
+++ b/java/src/test/java/com/ncc/aif/ValidateCLITest.java
@@ -148,7 +148,7 @@ public class ValidateCLITest {
         @Test
         void hypothesisMaxSizeNegative() {
             expectUsageError(ValidateAIFCli.ERR_BAD_ARGTYPE.replaceAll("%.", ""),
-                    "--ldc", "--hypothesis-max-size", "s", "-10", "2", "-f", "tmp.ttl");
+                    "--ldc", "--hypothesis-max-size", "-10", "2", "-f", "tmp.ttl");
         }
         @Test
         void hypothesisMaxSizeValid() {


### PR DESCRIPTION
- Created new hypothesis-max-size command line argument that controls the maximum size for a hypothesis file during validation
- Added tests to test new hypothesis-max-size cli argument
- Updated documentation for `--hypothesis-max-size` argument