### PR TITLE
Aida 1242

### DIFF
--- a/java/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
+++ b/java/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  */
 public class ThreadedValidationEngine extends ValidationEngine {
     private static boolean initialized = false;
-    private static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
+    private static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(ThreadedValidationEngine.class));
     private static void initializeSHComponents() {
         if (!initialized) {
             FunctionRegistry.get().put(TOSH.hasShape.getURI(), ThreadSafeHasShapeFunction.class);

--- a/java/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
+++ b/java/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
@@ -100,8 +100,6 @@ public class ThreadedValidationEngine extends ValidationEngine {
         }
 
         public void add(ConstraintTaskMetadata cmd) {
-            logger.debug("Completed " + shapeName + ":" + cmd.constraintName +
-                    ", t=" + cmd.threadName + ", d=" + cmd.duration);
             totalDuration += cmd.duration;
             violations += cmd.violations;
             reports.add(cmd.report);
@@ -356,10 +354,12 @@ public class ThreadedValidationEngine extends ValidationEngine {
                 isStopped = true;
             }
 
+            final long duration = System.currentTimeMillis() - start;
+            logger.debug("Completed " + constraint.toString() + ", d=" + duration);
             return new ConstraintTaskMetadata(
                     Thread.currentThread().getName(),
                     ConstraintTaskMetadata.getName(constraint),
-                    System.currentTimeMillis() - start,
+                    duration,
                     threadReport.get(),
                     threadViolations.get());
         };

--- a/java/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
+++ b/java/src/main/java/com/ncc/aif/ThreadedValidationEngine.java
@@ -319,8 +319,8 @@ public class ThreadedValidationEngine extends ValidationEngine {
                 smd.filteredTargetCount = filtered.size();
 
                 if (smd.targetCount > 0) {
-                    logger.debug("Collected {} target node(s) {}for {}, d={}", smd.targetCount,
-                            (smd.targetCount == smd.filteredTargetCount) ? "" : "(" + smd.filteredTargetCount + " after filter) ",
+                    logger.debug("Collected {} target node(s) ({} after filter) for {}, d={}",
+                            smd.targetCount, smd.filteredTargetCount,
                             shape.getShapeResource().getLocalName(), (System.currentTimeMillis() - start));
                 }
 

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -175,6 +175,9 @@ public class ValidateAIFCli implements Callable<Integer> {
     @Option(names = "--disk", description = "Use disk-based model for validating very large files")
     private boolean useDiskModel;
 
+    @Option(names = "--debug", description = "Enable debugging", hidden = true)
+    private boolean debugOutput;
+
     @Option(names = "-p", description = "Enable profiling", hidden = true)
     private boolean useProfiling;
 
@@ -338,6 +341,9 @@ public class ValidateAIFCli implements Callable<Integer> {
             logger.info("-> Validation will use " + threads + " threads.");
             validator.setThreadCount(threads);
         }
+        if (debugOutput) {
+            logger.setLevel(Level.DEBUG);
+        }
         if (depthSet) {
             logger.info("-> Performing shallow validation on " + depth + " target node(s) per rule.");
             validator.setDepth(depth);
@@ -353,8 +359,13 @@ public class ValidateAIFCli implements Callable<Integer> {
         if (profiling) {
             logger.info("-> Saving slow queries (> " + LONG_QUERY_THRESH + " ms) to <kbname>-stats.txt.");
         }
-        if (useProgressMonitor && !threadSet) {
-            logger.info("-> Saving ongoing validation progress to <kbname>-progress.tab.");
+        if (useProgressMonitor) {
+            if (threadSet) {
+                logger.info("-> Saving thread metrics to <kbname>-performance.txt.");
+            }
+            else {
+                logger.info("-> Saving ongoing validation progress to <kbname>-progress.tab.");
+            }
         }
         logger.info("*** Beginning validation of " + filesToValidate.size() + " file(s). ***");
 
@@ -394,7 +405,7 @@ public class ValidateAIFCli implements Callable<Integer> {
                 if (profiling) {
                     stats.startCollection();
                 }
-                if (useProgressMonitor) {
+                if (useProgressMonitor && !threadSet) {
                     String filename = fileToValidate.getName().replace(".ttl", "") + "-progress.tab";
                     ProgressMonitor pm;
                     try {
@@ -431,7 +442,6 @@ public class ValidateAIFCli implements Callable<Integer> {
                 // TODO: replace this when multi-threaded progress monitor exists
                 if (useProgressMonitor && threadSet) {
                     String outputFilename = fileToValidate.toString().replace(".ttl", "-performance.txt");
-                    logger.info("---> Saving thread metrics to " + outputFilename + ".");
                     try (PrintStream ps = new PrintStream(Files.newOutputStream(Paths.get(outputFilename)))) {
                         validator.printMetrics(ps);
                     } catch (IOException e) {

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -342,8 +342,8 @@ public class ValidateAIFCli implements Callable<Integer> {
             validator.setThreadCount(threads);
         }
         if (debugOutput) {
-            logger.info("-> Multi-threaded validation debugging output enabled.");
-            ((Logger) (org.slf4j.LoggerFactory.getLogger(ThreadedValidationEngine.class))).setLevel(Level.DEBUG);;
+            logger.info("-> Validation debugging output enabled.");
+            validator.setDebugging(true);
         }
         if (depthSet) {
             logger.info("-> Performing shallow validation on " + depth + " target node(s) per rule.");

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -23,7 +23,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
-import javax.security.auth.login.LoginException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -74,7 +73,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     // Internal Constants
     // ----------------------------
     // Logger
-    public static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
+    private static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
     // ViolationThreshold
     private static final String ABORT_PARAMETER_STRING = "Abort parameter";
     private static final int DEFAULT_MAX_VIOLATIONS = 3;
@@ -343,9 +342,8 @@ public class ValidateAIFCli implements Callable<Integer> {
             validator.setThreadCount(threads);
         }
         if (debugOutput) {
-            logger.setLevel(Level.DEBUG);
-            // Suppress hundreds of thousands of Jena LockMRSW lock messages.
-            ((Logger) (org.slf4j.LoggerFactory.getLogger(org.apache.jena.shared.LockMRSW.class))).setLevel(Level.INFO);;
+            logger.info("-> Multi-threaded validation debugging output enabled.");
+            ((Logger) (org.slf4j.LoggerFactory.getLogger(ThreadedValidationEngine.class))).setLevel(Level.DEBUG);;
         }
         if (depthSet) {
             logger.info("-> Performing shallow validation on " + depth + " target node(s) per rule.");

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -23,6 +23,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
+import javax.security.auth.login.LoginException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -73,7 +74,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     // Internal Constants
     // ----------------------------
     // Logger
-    private static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
+    public static final Logger logger = (Logger) (org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
     // ViolationThreshold
     private static final String ABORT_PARAMETER_STRING = "Abort parameter";
     private static final int DEFAULT_MAX_VIOLATIONS = 3;
@@ -343,6 +344,8 @@ public class ValidateAIFCli implements Callable<Integer> {
         }
         if (debugOutput) {
             logger.setLevel(Level.DEBUG);
+            // Suppress hundreds of thousands of Jena LockMRSW lock messages.
+            ((Logger) (org.slf4j.LoggerFactory.getLogger(org.apache.jena.shared.LockMRSW.class))).setLevel(Level.INFO);;
         }
         if (depthSet) {
             logger.info("-> Performing shallow validation on " + depth + " target node(s) per rule.");


### PR DESCRIPTION
Added `--debug` switch that enabled debug output (logging) to the multi-threaded validator.
When debugging is enabled, I suggest saving program output to a file and simplifying the output with `cut -d " " -f 1-2,6- filename.txt > cleanfile.txt`.

When testing, make sure to enable the multi-threaded validator with `-t`.