### PR TITLE
AIDA-1357: Documented Java 11 requirement

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -1,5 +1,15 @@
 # Installation
 
+AIF is built with Java version 11.  You can download JDL 11 from several places:
+* [Oracle JDK 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
+(but be sure to read their [licensing FAQ](https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html));
+* [Oracle OpenJDK 11](http://openjdk.java.net/projects/jdk/11/);
+* [AdoptOpenJDK](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot) (see their [Migration Guide](https://adoptopenjdk.net/migration.html))
+
+If your current code is based on a version of Java earlier than Java 11, you may need to update your code as well.
+If you must remain in an earlier Java environment (JDK 8 through 10), see the section entitled,
+[Building AIF with an earlier version of Java](#building-aif-with-an-earlier-version-of-java).
+
 To install the Java code, do `mvn install` from the `java` directory in this repository using Apache Maven.
 Repeat this if you pull an updated version of the code. You can run the tests,
 which should output the examples, by doing `mvn test`.
@@ -40,6 +50,25 @@ If you need to edit the Java code:
  3. Choose the `pom.xml` for this repository and accept all defaults.
 
 You should now be ready to go.
+
+# Building AIF with an earlier version of Java
+
+To build AIF with Java 9 or 10, change the value of the `<release>` tag in the `pom.xml` file to `9` or
+`10` respectively.
+
+To build with Java 8, replace the `maven-compiler-plugin`'s `<configuration>` tag with:
+
+```
+<configuration>
+  <source>8</source>
+  <target>8</target>
+  <compilerArgs>
+    <arg>-Xbootclasspath:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar</arg>
+  </compilerArgs>
+</configuration>
+```
+
+Set the `-Xbootclasspath` to the path of your Java 8 runtime jar file (rt.jar).
 
 # Documentation
 


### PR DESCRIPTION
Added documentation about Java 11 requirement.
I'm re-testing the build with Java 8 section now on Linux, but wanted to get this into code review.