### PR TITLE
AIDA-1372: Add example to generate LDCTime ranges

### DIFF
--- a/java/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/java/src/main/java/com/ncc/aif/AIFUtils.java
@@ -1507,7 +1507,10 @@ public class AIFUtils {
      * @param system The system object for the system which marks the time
      * @return
      */
-    public static Resource markLDCTimeRange(Model model, Resource toMark, LDCTimeComponent startEarliest, LDCTimeComponent startLatest, LDCTimeComponent endEarliest, LDCTimeComponent endLatest, Resource system) {
+    public static Resource markLDCTimeRange(Model model, Resource toMark,
+                                            LDCTimeComponent startEarliest, LDCTimeComponent startLatest,
+                                            LDCTimeComponent endEarliest, LDCTimeComponent endLatest,
+                                            Resource system) {
         final Resource ldcTime = makeAIFResource(model, null, AidaAnnotationOntology.LDC_TIME_CLASS, system);
         if (endLatest != null) {
             ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_END, endLatest.makeAIFTimeComponent(model));

--- a/java/src/main/java/com/ncc/aif/AIFUtils.java
+++ b/java/src/main/java/com/ncc/aif/AIFUtils.java
@@ -1495,6 +1495,37 @@ public class AIFUtils {
         return ldcTime;
     }
 
+    /**
+     * Add LDC start and end time ranges representation to an Event or Relation
+     *
+     * @param model  The underlying RDF model for the operation
+     * @param toMark The Event or Relation to add the LDC time data to
+     * @param startEarliest  {@link LDCTimeComponent} containing the earliest start time in the range
+     * @param startLatest    {@link LDCTimeComponent} containing the latest start time in the range
+     * @param endEarliest    {@link LDCTimeComponent} containing the earliest end time in the range
+     * @param endLatest      {@link LDCTimeComponent} containing the latest end time in the range
+     * @param system The system object for the system which marks the time
+     * @return
+     */
+    public static Resource markLDCTimeRange(Model model, Resource toMark, LDCTimeComponent startEarliest, LDCTimeComponent startLatest, LDCTimeComponent endEarliest, LDCTimeComponent endLatest, Resource system) {
+        final Resource ldcTime = makeAIFResource(model, null, AidaAnnotationOntology.LDC_TIME_CLASS, system);
+        if (endLatest != null) {
+            ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_END, endLatest.makeAIFTimeComponent(model));
+        }
+        if (endEarliest != null) {
+            ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_END, endEarliest.makeAIFTimeComponent(model));
+        }
+        if (startLatest != null) {
+            ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_START, startLatest.makeAIFTimeComponent(model));
+        }
+        if (startEarliest != null) {
+            ldcTime.addProperty(AidaAnnotationOntology.LDC_TIME_START, startEarliest.makeAIFTimeComponent(model));
+        }
+
+        toMark.addProperty(AidaAnnotationOntology.LDC_TIME_PROPERTY, ldcTime);
+        return ldcTime;
+    }
+
     // Helper function to create an event, relation, justification, etc. in the system.
     private static Resource makeAIFResource(@Nonnull Model model, @Nullable String uri, @Nonnull Resource classType, @Nullable Resource system) {
         Resource resource = (uri == null ? model.createResource() : model.createResource(uri));

--- a/java/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/java/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -1170,33 +1170,30 @@ public class ExamplesAndValidationTest {
         @Test
         void createEventsWithLDCTimeRanges() {
             // Create a arrest jail event that started in first quarter of 2013 and ended on April 15, 2013
-            final Resource eventAttack1 = utils.makeValidAIFEvent(SeedlingOntology.Justice_ArrestJail);
+            final Resource event1 = utils.makeValidAIFEvent(SeedlingOntology.Justice_ArrestJail);
             LDCTimeComponent startRangeEarliest, startRangeLatest;
             LDCTimeComponent endRangeEarliest, endRangeLatest;
             startRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2013", "--01", "---01");
-            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2013", "--03", "---31");
-            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2013", "--04", "---15");
-            endRangeLatest = endRangeEarliest;
-            markLDCTime(model, eventAttack1, startRangeEarliest, endRangeEarliest, system);
-            markLDCTime(model, eventAttack1, startRangeLatest, endRangeLatest, system);
+            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2013", "--03", "---31");
+            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2013", "--04", "---15");
+            endRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2013", "--04", "---15");
+            markLDCTimeRange(model, event1, startRangeEarliest, startRangeLatest, endRangeEarliest, endRangeLatest, system);
 
             // Create a transfer money event that started in March 2010 and ended sometime after 2010
-            final Resource eventAttack2 = utils.makeValidAIFEvent(SeedlingOntology.Transaction_TransferMoney);
+            final Resource event2 = utils.makeValidAIFEvent(SeedlingOntology.Transaction_TransferMoney);
             startRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2010", "--02", "---01");
-            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2010", "--02", "---28");
-            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2010", "--12", "---31");
+            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2010", "--02", "---28");
+            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2010", "--12", "---31");
             endRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "9999", "--12", "---31");
-            markLDCTime(model, eventAttack2, startRangeEarliest, endRangeEarliest, system);
-            markLDCTime(model, eventAttack2, startRangeLatest, endRangeLatest, system);
+            markLDCTimeRange(model, event2, startRangeEarliest, startRangeLatest, endRangeEarliest, endRangeLatest, system);
 
             // Create a conflict attack event with that started in March 2010 and ended sometime after 2010
-            final Resource eventAttack3 = utils.makeValidAIFEvent(SeedlingOntology.Conflict_Attack);
+            final Resource event3 = utils.makeValidAIFEvent(SeedlingOntology.Conflict_Attack);
             startRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "-9999", "--01", "---01");
-            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2016", "--02", "---01");
-            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2017", "--01", "---01");
+            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2016", "--02", "---01");
+            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2017", "--01", "---01");
             endRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2017", "--12", "---31");
-            markLDCTime(model, eventAttack3, startRangeEarliest, endRangeEarliest, system);
-            markLDCTime(model, eventAttack3, startRangeLatest, endRangeLatest, system);
+            markLDCTimeRange(model, event3, startRangeEarliest, startRangeLatest, endRangeEarliest, endRangeLatest, system);
 
             utils.testValid("create events with LDCTime ranges");
         }

--- a/java/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/java/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -39,10 +39,10 @@ public class ExamplesAndValidationTest {
     // Modify these flags to control how tests output their models/reports and if so, how they output them
     // When DUMP_ALWAYS is false, the model is only dumped when the result is unexpected (and if invalid, the report is also dumped)
     // When DUMP_ALWAYS is true, the model is always dumped, and the report is always dumped if invalid
-    private static final boolean DUMP_ALWAYS = false;
+    private static final boolean DUMP_ALWAYS = true;
     // When DUMP_TO_FILE is false, if a model or report is dumped, it goes to stdout
     // WHen DUMP_TO_FILE is true, if a model or report is dumped, it goes to a file in target/test-dump-output
-    private static final boolean DUMP_TO_FILE = false;
+    private static final boolean DUMP_TO_FILE = true;
 
     private static final String NIST_ROOT = "https://tac.nist.gov/tracks/SM-KBP/";
     private static final String LDC_NS = NIST_ROOT + "2019/LdcAnnotations#";
@@ -1165,6 +1165,40 @@ public class ExamplesAndValidationTest {
             markJustification(time, utils.makeValidJustification());
 
             utils.testValid("create an event with LDCTime");
+        }
+
+        @Test
+        void createEventsWithLDCTimeRanges() {
+            // Create a arrest jail event that started in first quarter of 2013 and ended on April 15, 2013
+            final Resource eventAttack1 = utils.makeValidAIFEvent(SeedlingOntology.Justice_ArrestJail);
+            LDCTimeComponent startRangeEarliest, startRangeLatest;
+            LDCTimeComponent endRangeEarliest, endRangeLatest;
+            startRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2013", "--01", "---01");
+            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2013", "--03", "---31");
+            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2013", "--04", "---15");
+            endRangeLatest = endRangeEarliest;
+            markLDCTime(model, eventAttack1, startRangeEarliest, endRangeEarliest, system);
+            markLDCTime(model, eventAttack1, startRangeLatest, endRangeLatest, system);
+
+            // Create a transfer money event that started in March 2010 and ended sometime after 2010
+            final Resource eventAttack2 = utils.makeValidAIFEvent(SeedlingOntology.Transaction_TransferMoney);
+            startRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2010", "--02", "---01");
+            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2010", "--02", "---28");
+            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2010", "--12", "---31");
+            endRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "9999", "--12", "---31");
+            markLDCTime(model, eventAttack2, startRangeEarliest, endRangeEarliest, system);
+            markLDCTime(model, eventAttack2, startRangeLatest, endRangeLatest, system);
+
+            // Create a conflict attack event with that started in March 2010 and ended sometime after 2010
+            final Resource eventAttack3 = utils.makeValidAIFEvent(SeedlingOntology.Conflict_Attack);
+            startRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "-9999", "--01", "---01");
+            startRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.AFTER, "2016", "--02", "---01");
+            endRangeEarliest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2017", "--01", "---01");
+            endRangeLatest = new LDCTimeComponent(LDCTimeComponent.LDCTimeType.BEFORE, "2017", "--12", "---31");
+            markLDCTime(model, eventAttack3, startRangeEarliest, endRangeEarliest, system);
+            markLDCTime(model, eventAttack3, startRangeLatest, endRangeLatest, system);
+
+            utils.testValid("create events with LDCTime ranges");
         }
 
         /**

--- a/java/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
+++ b/java/src/test/java/com/ncc/aif/ExamplesAndValidationTest.java
@@ -39,10 +39,10 @@ public class ExamplesAndValidationTest {
     // Modify these flags to control how tests output their models/reports and if so, how they output them
     // When DUMP_ALWAYS is false, the model is only dumped when the result is unexpected (and if invalid, the report is also dumped)
     // When DUMP_ALWAYS is true, the model is always dumped, and the report is always dumped if invalid
-    private static final boolean DUMP_ALWAYS = true;
+    private static final boolean DUMP_ALWAYS = false;
     // When DUMP_TO_FILE is false, if a model or report is dumped, it goes to stdout
     // WHen DUMP_TO_FILE is true, if a model or report is dumped, it goes to a file in target/test-dump-output
-    private static final boolean DUMP_TO_FILE = true;
+    private static final boolean DUMP_TO_FILE = false;
 
     private static final String NIST_ROOT = "https://tac.nist.gov/tracks/SM-KBP/";
     private static final String LDC_NS = NIST_ROOT + "2019/LdcAnnotations#";


### PR DESCRIPTION
The example test added in this branch generates the AIF shown on the "Support for Composite Cluster Member Information" to be made public to teams after review.
Note - I set the DUMP_ALWAYS and DUMP_TO_FILE constants to true, so you can easily find this generated example in java/target/test-dump-output/ExamplesAndValidationTest_ValidExamples_createEventsWithLDCTimeRanges.ttl
Before it gets merged in, these constants should be changed back to false.