### PR TITLE
AIDA-1459: Initial commit standalone AIF validator container image

### DIFF
--- a/docker/aif-validator/.gitignore
+++ b/docker/aif-validator/.gitignore
@@ -1,0 +1,2 @@
+run.sh
+build.sh

--- a/docker/aif-validator/Dockerfile
+++ b/docker/aif-validator/Dockerfile
@@ -39,24 +39,20 @@ ENV VALIDATION_HOME /opt/aif-validator
 RUN mkdir $VALIDATION_HOME
 
 # Define default arguments if nothing is supplied using --build-args
-ARG GIT_REPO
-ARG VALIDATOR_REPO
-ARG VALIDATOR_BRANCH
+ARG GIT_REPO=github.com
+ARG VALIDATOR_REPO=NextCenturyCorporation/AIDA-Interchange-Format.git
+ARG VALIDATOR_BRANCH=master
 
 # Pull Git Repository
-WORKDIR /tmp
-RUN git clone https://$GIT_REPO/$VALIDATOR_REPO -b $VALIDATOR_BRANCH
+WORKDIR $VALIDATION_HOME
+RUN git clone https://$GIT_REPO/$VALIDATOR_REPO -b $VALIDATOR_BRANCH .
 
 # Run Maven Build
-WORKDIR /tmp/AIDA-Interchange-Format/java
+WORKDIR $VALIDATION_HOME/java
 RUN mvn clean -Dmaven.test.skip=true package
-
-# Copy repo to aif validation directory
-RUN cp -R /tmp/AIDA-Interchange-Format/* $VALIDATION_HOME
 
 # clean up set working directory to home
 RUN yum clean all && \
-    rm -rf /tmp/AIDA-Interchange-Format && \
     rm -rf /var/cache/yum
 WORKDIR $HOME
 

--- a/docker/aif-validator/Dockerfile
+++ b/docker/aif-validator/Dockerfile
@@ -1,0 +1,65 @@
+FROM amazonlinux:latest
+MAINTAINER craig.warsaw@caci.com
+
+# Update system packages and remove any downloaded files
+RUN yum update --assumeyes --skip-broken && \
+	yum install --assumeyes git vim python37 tar
+
+ENV HOME /root
+
+#-------------------------------------------------------------
+#  Install Java OpenJDK 11
+#-------------------------------------------------------------
+RUN yum install -y java-11-amazon-corretto-headless
+
+ENV JAVA_HOME /etc/alternatives/jre
+
+#-------------------------------------------------------------
+#  Install Maven
+#------------------------------------------------------------
+ARG MAVEN_VERSION=3.6.3
+ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$HOME/.m2"
+
+#-------------------------------------------------------------
+# Install AIF Interchange Format
+#------------------------------------------------------------- 
+# Create directory structure
+ENV VALIDATION_HOME /opt/aif-validator
+RUN mkdir $VALIDATION_HOME
+
+# Define default arguments if nothing is supplied using --build-args
+ARG GIT_REPO
+ARG VALIDATOR_REPO
+ARG VALIDATOR_BRANCH
+
+# Pull Git Repository
+WORKDIR /tmp
+RUN git clone https://$GIT_REPO/$VALIDATOR_REPO -b $VALIDATOR_BRANCH
+
+# Run Maven Build
+WORKDIR /tmp/AIDA-Interchange-Format/java
+RUN mvn clean -Dmaven.test.skip=true package
+
+# Copy repo to aif validation directory
+RUN cp -R /tmp/AIDA-Interchange-Format/* $VALIDATION_HOME
+
+# clean up set working directory to home
+RUN yum clean all && \
+    rm -rf /tmp/AIDA-Interchange-Format && \
+    rm -rf /var/cache/yum
+WORKDIR $HOME
+
+COPY ["scripts/main.py", "/usr/local/"]
+ENTRYPOINT ["python3", "/usr/local/main.py"]
+

--- a/docker/aif-validator/README.md
+++ b/docker/aif-validator/README.md
@@ -1,0 +1,78 @@
+# AIF Validator Docker
+
+## Setup
+
+### Install Docker
+
+First install Docker. Here is a detailed guide on installing Docker on Ubuntu: [How to install and Use Docker on Ubuntu 18.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-18-04).
+
+### Setup Docker experimentals
+
+This is an optional step, but is highly **recommended**. Docker has an experimental feature called squash. Squashing
+your Docker image during the build process will significantly reduce the size of your final Docker image. To leverage
+the `--squash` flag during the build process you must enable experimental Docker functions. 
+
+To enable, edit `/etc/docker/daemon.json` and insert the following:
+
+```json
+{
+	"experimental": true
+}
+```
+
+Save, restart Docker via `service docker restart` and confirm experimental is enabled on the server. The following command will return `true` if experimental is enabled, `false` otherwise. 
+```
+$ docker version -f '{{.Server.Experimental}}'
+```
+
+## AIF Validator
+
+The AIF Validator Docker image is responsible for taking in TTL files, running validation on the files, producing validation reports of the invalid TTL files, and a log of the validation.
+
+### Building AIF Validator Docker image
+
+To build the Docker image, copy the `build.sh.example` file provided to a new file, `build.sh`. 
+This script contains the `--squash` flag, which is optional but recommended. You must enable Docker experimentals on the server if you would like to use this. See [Setup Docker experimentals](#Setup-Docker-experimentals). If your system is not enabled to use squash or you would prefer not to use the `--squash` flag you can remove it from your `build.sh`.
+
+### Execute the build
+
+Once you have updated all the build arguments with your appropriate values, execute the build script with:
+```bash
+$ chmod +x build.sh
+$ ./build.sh
+```
+
+### Running the container
+
+To run the AIF Validator Docker container, the `run.sh.example` script shows one way to run it.  You can copy the `run.sh.example` script to a new file, `run.sh`. The run script will start the Docker container. Before executing the script, update the passed in Docker environment variables within the `run.sh` script. These environment variables should be configured to meet your needs for your particular AIF Validator execution. Each variable is described in the table below.
+
+
+| Env Variable            | Description                                                    | Default              |
+| :---------------------- | :------------------------------------------------------------- | :------------------- |
+| `VALIDATION_HOME`       | Location in the container for the built, git clone of AIF      | `/opt/aif-validator` |
+| `VALIDATION_FLAGS`      | Flags sent to the AIF validator (see below)                    | none                 |
+| `VALIDATION_LOG`        | `stdout` or a file in the mounted directory to save the log    | `stdout`             |
+| `VALIDATE_DIR_OR_FILES` | Either `directory` or `files`                                  | `directory`          |
+| `TARGET_TO_VALIDATE`    | The directory to validate OR the space separated list of files | `${pwd}`             |
+
+
+Execute the run script with:
+
+```bash
+$ chmod +x run.sh
+$ ./run.sh
+```
+
+### VALIDATION_FLAGS variable
+
+You can set the `VALIDATION_FLAGS` environment variable to any combination of flags as specified in the [Running the Java AIF validator section of the top-level AIF README](https://github.com/NextCenturyCorporation/AIDA-Interchange-Format#running-the-java-aif-validator).
+
+Or you can use a shortcut specifying a combination of flags that we've found work well for each AIDA task area.  See the table below.
+
+| VALIDATION_FLAG option | Expanded VALIDATION_FLAGs |
+| :--------------------- | :------------------------ |
+| `--TA1`                | `--ldc --nist -o`         |
+| `--TA2`                | `--ldc --nist --disk -o`  |
+| `--TA3`                | `--ldc --nist-ta3 -o`     |
+
+You cannot use more than one of these shortcut options in a single invocation.

--- a/docker/aif-validator/build.sh.example
+++ b/docker/aif-validator/build.sh.example
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker build --no-cache \
+	--build-arg GIT_REPO=github.com \
+	--build-arg VALIDATOR_REPO=NextCenturyCorporation/AIDA-Interchange-Format.git \
+	--build-arg VALIDATOR_BRANCH=master \
+	--squash \
+	-t aif-validator .

--- a/docker/aif-validator/build.sh.example
+++ b/docker/aif-validator/build.sh.example
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 docker build --no-cache \
-	--build-arg GIT_REPO=github.com \
-	--build-arg VALIDATOR_REPO=NextCenturyCorporation/AIDA-Interchange-Format.git \
-	--build-arg VALIDATOR_BRANCH=master \
+`# Default arguments defined in Dockerfile. Uncomment to override.` \
+`#	--build-arg GIT_REPO=github.com `\
+`#	--build-arg VALIDATOR_REPO=NextCenturyCorporation/AIDA-Interchange-Format.git `\
+`#	--build-arg VALIDATOR_BRANCH=master `\
 	--squash \
 	-t aif-validator .

--- a/docker/aif-validator/run.sh.example
+++ b/docker/aif-validator/run.sh.example
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Mount the current directory to the container
+# Validate all TTL in the current directory as a TA1
+# Save the output in a log file in the current directory
+docker run --rm -it \
+       -v $(pwd):/v \
+       -e VALIDATION_HOME='/opt/aif-validator' \
+       -e VALIDATION_FLAGS='--TA1' \
+       -e VALIDATION_LOG='/v/validate_log.out' \
+       -e VALIDATE_DIR_OR_FILES='directory' \
+       -e TARGET_TO_VALIDATE='/v' \
+       --name aif-validator \
+       aif-validator
+

--- a/docker/aif-validator/scripts/main.py
+++ b/docker/aif-validator/scripts/main.py
@@ -1,0 +1,164 @@
+import os
+import logging
+import subprocess
+from pathlib import Path
+from subprocess import PIPE, CalledProcessError
+
+class Main:
+
+    # Initialize instance attributes
+    def __init__(self, envs):
+        self.validation_home = envs['VALIDATION_HOME']
+        self.validation_flags = envs['VALIDATION_FLAGS']
+        self.validation_log = envs['VALIDATION_LOG']
+        self.validate_dir_or_files = envs['VALIDATE_DIR_OR_FILES']
+        self.target_to_validate = envs['TARGET_TO_VALIDATE']
+
+    def run(self):
+        # If validation flags contains one of TA1, TA2, or TA3, then expand the flags to the optimal set of flags 
+        # for that use case.  Only one of these will run since the environment variables were validated 
+        #before they get here
+        self.validation_flags = self.validation_flags.replace("--TA1", "--ldc --nist -o")
+        self.validation_flags = self.validation_flags.replace("--TA2", "--ldc --nist --disk -o")
+        self.validation_flags = self.validation_flags.replace("--TA3", "--ldc --nist-ta3 -o")
+
+        logging.info("Validation flags = [%s]", self.validation_flags);
+        logging.info("Validation home = [%s]", self.validation_home);
+        if self.validation_log == 'stdout':
+            logging.info("Validation output will be sent to stdout");
+        else:
+            logging.info("Validation output will be captured in log file = [%s]", self.validation_log);
+        logging.info("Validate directory or files = [%s]", self.validate_dir_or_files);
+        logging.info("Target to validate = [%s]", self.target_to_validate);
+        self._execute_validation();
+
+    def _execute_validation(self):
+        """Executes the AIF Validator as a sub-process for the turtle files
+        in target directory or target files
+
+        :returns: Return code that specifies the validation execution result 
+        :rtype: int
+        """
+        try:
+            cmd_flags = self.validation_flags
+            if self.validate_dir_or_files == 'directory':
+                cmd_flags += ' -d='
+            else:
+                cmd_flags += ' -f='
+
+            cmd_flags += self.target_to_validate
+            cmd = self.validation_home + '/java/target/appassembler/bin/validateAIF ' + cmd_flags
+            
+            logging.info("Executing AIF Validation with flags [%s]", cmd_flags)
+            #***********************
+            # Requires python 3.7+ *
+            #***********************
+            if self.validation_log == 'stdout':
+                output = subprocess.run(cmd, stdout=None, check=True, shell=True, universal_newlines=True)
+            else:
+                output = subprocess.run(cmd, stdout=PIPE, check=True, shell=True, universal_newlines=True)
+
+                f = open(self.validation_log, 'w')
+                f.write(output.stdout)
+                f.close()
+
+            logging.info("All files valid.  Validation succeeded with flags [%s]", cmd_flags)
+            return 0
+
+        except CalledProcessError as e:
+            if self.validation_log != 'stdout':
+                f = open(self.validation_log, 'w')
+                f.write(e.output)
+                f.close()
+            if e.returncode == 1:
+                logging.info("Validation completed with flags [%s] but at least one file had validation errors", cmd_flags)
+                return 0
+            else:
+                logging.info("Validation failed with cmd [%s] with error code [%s]", cmd, str(e.returncode))
+                return e.returncode
+
+def read_envs():
+    """Function will read in all environment variables into a dictionary
+
+    :returns: Dictionary containing all environment variables or defaults
+    :rtype: dict
+    """
+    envs = {}
+    envs['VALIDATION_HOME'] = os.environ.get('VALIDATION_HOME', '/opt/aif-validator')
+    envs['VALIDATION_FLAGS'] = os.environ.get('VALIDATION_FLAGS')
+
+    # TBD should default be stdout or log to a file?
+    envs['VALIDATION_LOG'] = os.environ.get('VALIDATION_LOG', 'stdout')
+    #envs['VALIDATION_LOG'] = os.environ.get('VALIDATION_LOG', './validation_log.out')
+
+    # Default is to validate files in current directory
+    # TODO file wildcarding doesn't work.
+    #    To specify a single file, set VALIDATE_DIR_OR_FILES to 'files' and TARGET_TO_VALIDATE to a TTL file
+    #    TO specify multiple files, must set TARGET_TO_VALIDATE to a space separated list of files
+    envs['VALIDATE_DIR_OR_FILES'] = os.environ.get('VALIDATE_DIR_OR_FILES', 'directory')
+    envs['TARGET_TO_VALIDATE'] = os.environ.get('TARGET_TO_VALIDATE', '.')
+
+    return envs
+
+def validate_envs(envs: dict):
+    """Helper function to validate all of the environment variables exist and are valid before
+    processing starts.
+
+    :param dict envs: Dictionary of all environment variables
+    :returns: True if all environment variables are valid, False otherwise
+    :rtype: bool
+    """
+
+    if not bool(envs):
+        logging.error("No environment variables found")
+        return False
+
+    for k, v in envs.items():
+        if not is_env_set(k, v):
+            return False
+
+    if envs['VALIDATE_DIR_OR_FILES'] != "directory" and envs['VALIDATE_DIR_OR_FILES'] != "files":
+        logging.error("dir_or_files is [%s] but must be either \'directory\' or \'files\'", envs['VALIDATE_DIR_OR_FILES'])
+        return False
+    
+    # You can pass zero or a max of one of --TA1, --TA2, or --TA3 parameters
+    if envs['VALIDATION_FLAGS'].count("--TA") > 1:
+        logging.error("Validation flags [%s] cannot specify more than one TA Task Type", envs['VALIDATION_FLAGS'])
+        return False
+    
+    return True
+    
+
+def is_env_set(env, value):
+    """Helper function to check if a specific environment variable is not None
+
+    :param str env: The name of the environment variable
+    :param value: The value of the environment variable
+    :returns: True if environment variable is set, False otherwise
+    :rtype: bool
+    """
+    if not value:
+        logging.error("Environment variable [%s] is not set", env)
+        return False
+
+    logging.info("Environment variable [%s] is set to [%s]", env, value)
+    return True
+
+
+def main():
+
+    # validate environment variables
+    envs = read_envs()
+    
+    # set logging to log to stdout
+    logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO'))
+
+    if validate_envs(envs):
+
+        main = Main(envs)
+        main.run()
+
+    else:
+        raise ValueError("Exception occurred when validating environment variables")
+
+if __name__ == "__main__": main()


### PR DESCRIPTION
This AIF validator container is adapted from the existing batch-init / batch-single containers but is meant to be run locally (i.e., not in AWS Batch).  This is intended to be inserted into the evaluation pipeline after an algorithm runs and before the finalizer, however, I think there may be stand-alone uses for it.
Currently, all parameters are passed in as environment variables.  Arguably, passing them in as command-line variables to the ENTRYPOINT may be (more? or less?) useful.  
Feedback on any of this is welcome.