### PR TITLE
added - Associated KEs must have cluster >=1

### DIFF
--- a/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
@@ -170,29 +170,41 @@ aida:ClaimShape
 #########################
 # 2.4 #16. The graph of Associated KEs must have at least one event cluster or relation cluster with at least one edge.
 # TODO: Checkwith NIST
-# aida:SystemShape
-#     sh:sparql[
-#         sh:message "Each Associated KEs graph must have at least one event or relation with at least one edge. Found {$this}" ;
-#         sh:select """
-#             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-#             PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-#             PREFIX aidaDomainCommon: <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/AidaDomainOntologiesCommon#>
-#             SELECT (COUNT(?pred) AS $this)
-#             WHERE {
-#                 ?argumentAssertion a rdf:Statement .
-#                 ?argumentAssertion rdf:predicate ?pred .
-#                 {
-#                     ?pred rdfs:subClassOf+ aidaDomainCommon:RelationArgumentType
-#                 }
-#                 UNION
-#                 {
-#                     ?pred rdfs:subClassOf+ aidaDomainCommon:EventArgumentType
-#                 }
-#             }
-#             HAVING (COUNT(?pred) < 1)
-#         """ ;
+aida:SystemShape
+    sh:sparql[
+        sh:message "Each Associated KEs graph must have at least one event or relation with at least one edge. Found {$this}" ;
+        sh:select """
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+            PREFIX aidaDomainCommon: <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/AidaDomainOntologiesCommon#>
+            PREFIX aida:  <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology#>
 
-#     ] .
+            SELECT (COUNT(?pred) AS $this)
+            WHERE {
+                        ?claimId aida:associatedKEs ?subject_cluster .
+                        ?subject_cluster a aida:SameAsCluster .
+                        ?subject_cluster aida:prototype ?subject_prototype .
+                        ?subject_prototype a ?subject_metatype .
+                        ?object_cluster a aida:SameAsCluster .
+                        ?object_cluster aida:prototype ?object_prototype .
+
+
+
+                        ?statement a ?statement_type .
+                        ?statement rdf:object ?object_prototype .
+                        ?statement rdf:predicate ?predicate .
+                        ?statement rdf:subject ?subject_prototype .
+                        ?statement aida:confidence ?confidence .
+
+
+
+                        FILTER(?statement_type = rdf:Statement || ?statement_type = aida:ArgumentStatement)
+                        FILTER(?subject_metatype = aida:Event || ?subject_metatype = aida:Relation)        
+            }
+            HAVING (COUNT(?pred) >= 1)
+        """ ;
+
+    ] .
 #------------------------
 
 


### PR DESCRIPTION
Added shacl support for  2.4 #16. The graph of Associated KEs must have at least one event cluster or relation cluster with at least one edge.