### PR TITLE
Aida 2070

### DIFF
--- a/java/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -63,11 +63,18 @@ aida:ClusterMembershipShape
 
 ### Prevent prototype from being member of a cluster it is not the prototype of and 
 ### prevent it from being prototype of mulitple clusters
+
+###Removed per Hoa 2/16/2022
+#aida:PrototypeShape
+#    a sh:NodeShape ;
+#    sh:targetObjectsOf aida:prototype ;
+#    sh:property aida:PreventMultiClusterPrototypeShape ;
+#    sh:sparql aida:PreventNonClusterPrototypeMemberShape .
+
 aida:PrototypeShape
     a sh:NodeShape ;
     sh:targetObjectsOf aida:prototype ;
-    sh:property aida:PreventMultiClusterPrototypeShape ;
-    sh:sparql aida:PreventNonClusterPrototypeMemberShape .
+    sh:property aida:PreventMultiClusterPrototypeShape .
 
 ### Prototype can't be prototype of multiple clusters
 aida:PreventMultiClusterPrototypeShape

--- a/java/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -77,20 +77,22 @@ aida:PreventMultiClusterPrototypeShape
     sh:message "Prototype can't be prototype of multiple clusters" .
 
 ### Prototype can't be member of different cluster
-aida:PreventNonClusterPrototypeMemberShape
-    # Using SPARQL because unable to use sh:inversePath in sh:equals
-    a sh:SPARQLConstraint ;
-    sh:select """
-        PREFIX aida:  <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology#>
-      	SELECT $this $value
-      	WHERE {
-      	    $this ^aida:clusterMember / aida:cluster $value .
-            $this ^aida:prototype ?cluster .
-            FILTER ($value != ?cluster) .
-      	}
-    """ ;
+###Removed per Hoa 2/16/2022
+#####NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).
+# aida:PreventNonClusterPrototypeMemberShape
+#     # Using SPARQL because unable to use sh:inversePath in sh:equals
+#     a sh:SPARQLConstraint ;
+#     sh:select """
+#         PREFIX aida:  <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology#>
+#       	SELECT $this $value
+#       	WHERE {
+#       	    $this ^aida:clusterMember / aida:cluster $value .
+#             $this ^aida:prototype ?cluster .
+#             FILTER ($value != ?cluster) .
+#       	}
+#     """ ;
 
-    sh:message "Prototype can't be member of cluster it's not prototype of" .
+#     sh:message "Prototype can't be member of cluster it's not prototype of" .
 
 #------------------------
 

--- a/java/src/test/java/com/ncc/aif/NistExamplesAndValidationTest.java
+++ b/java/src/test/java/com/ncc/aif/NistExamplesAndValidationTest.java
@@ -812,20 +812,21 @@ public class NistExamplesAndValidationTest {
                utils.expect(ShaclShapes.PreventMultiClusterPrototypeShape, SH.MaxCountConstraintComponent, null);
                utils.testInvalid("Prototype.invalid: prototype of multiple clusters");
            }
+
+           //Removed per Hoa 2/16/2022
+        //    @Test
+        //    void invalidPrototypeMemberOfOther() {
+        //        // create sample entities
+        //        ImmutablePair<Resource, Resource> aPair = utils.makeValidNistEntity(
+        //            LDCOntology.PER);
+        //        final Resource entity2 = aPair.getKey();
  
-           @Test
-           void invalidPrototypeMemberOfOther() {
-               // create sample entities
-               ImmutablePair<Resource, Resource> aPair = utils.makeValidNistEntity(
-                   LDCOntology.PER);
-               final Resource entity2 = aPair.getKey();
+        //        // create two clusters with different prototypes
+        //        markAsPossibleClusterMember(model, entity2, entityCluster, 1d, system);
  
-               // create two clusters with different prototypes
-               markAsPossibleClusterMember(model, entity2, entityCluster, 1d, system);
- 
-               utils.expect(ShaclShapes.PrototypeShape, SH.SPARQLConstraintComponent, ShaclShapes.PreventNonClusterPrototypeMemberShape);
-               utils.testInvalid("Prototype.invalid: prototype member of other cluster");
-           }
+        //        utils.expect(ShaclShapes.PrototypeShape, SH.SPARQLConstraintComponent, ShaclShapes.PreventNonClusterPrototypeMemberShape);
+        //        utils.testInvalid("Prototype.invalid: prototype member of other cluster");
+        //    }
        }
  
        @Nested


### PR DESCRIPTION
From: Dang, Hoa T. (Fed) [hoa.dang@nist.gov](mailto:hoa.dang@nist.gov)
Sent: Wednesday, February 16, 2022 5:08 PM
To: Le, Phi - US [phi.le@caci.com](mailto:phi.le@caci.com)
Cc: Rajput, Shahzad K. (Assoc) [shahzad.rajput@nist.gov](mailto:shahzad.rajput@nist.gov)
Subject: NIST-restricted AIF

EXTERNAL EMAIL - This email originated from outside of CACI. Do not click any links or attachments unless you recognize and trust the sender.

Hi Phi,

I noticed that NIST-restricted AIF validator is flagging an error in GAIA TA2 dry run submission:

54666 - "Prototype can't be member of cluster it's not prototype of"

Can you remove this requirement from the NIST-restricted AIF?

NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

Thanks!

Hoa