### PR TITLE
Update subject prototype check for AssociatedKE's Event/Relation prot…

### DIFF
--- a/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
@@ -186,7 +186,10 @@ aida:SystemShape
                         ?subject_cluster aida:prototype ?subject_prototype .
                         ?subject_prototype a ?subject_metatype .
                         ?object_cluster a aida:SameAsCluster .
-                        ?object_cluster aida:prototype ?object_prototype .
+                       
+                        {{ ?subject_cluster aida:prototype ?subject_prototype }
+                            UNION
+                        {?object_cluster aida:prototype ?object_prototype }}
 
                         ?statement a ?statement_type .
                         ?statement rdf:object ?object_prototype .

--- a/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
@@ -183,7 +183,6 @@ aida:SystemShape
             WHERE {
                         ?claimId aida:associatedKEs ?subject_cluster .
                         ?subject_cluster a aida:SameAsCluster .
-                        ?subject_cluster aida:prototype ?subject_prototype .
                         ?subject_prototype a ?subject_metatype .
                         ?object_cluster a aida:SameAsCluster .
                        


### PR DESCRIPTION
This is in reference to:  "16. The graph of Associated KEs must have at least one event cluster or relation cluster with at least one edge" - Eval Plan

Hoa - It’s weird but not invalid for :associatedKEs to include an event cluster whose prototype is the object of an argument statement, without including the event or relation whose prototype is the subject of that argument statement:

cmuta1:corpora\/eval\/role\-stmt\-LhR25oJrfRzYrqttF2SEhn rdf:subject cmuta1:corpora\/eval\/event\-instance\-L0C049DU0\-r202201290059\-118 .

Remove Subject, as long as the prototype is in either of the subject or object of the argument statement then it should pass validation