### PR TITLE
Merge Develop to Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ build/
 # Python documentation
 python/docs/build/
 python/docs/source/*.rst
+java/src/main/resources/com/ncc/.DS_Store

--- a/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
+++ b/java/src/main/java/com/ncc/aif/ValidateAIFCli.java
@@ -195,7 +195,7 @@ public class ValidateAIFCli implements Callable<Integer> {
     // private boolean useDiskModel;
 
     @Option(names = "--mem", description = "Use memory model for validating files")
-    private boolean useMemModel;
+    private boolean useMemModel = true;
 
     @Option(names = "--debug", description = "Enable debugging", hidden = true)
     private boolean debugOutput;

--- a/java/src/main/java/com/ncc/aif/util/AIFOrderedTurtleWriter.java
+++ b/java/src/main/java/com/ncc/aif/util/AIFOrderedTurtleWriter.java
@@ -80,7 +80,7 @@ public class AIFOrderedTurtleWriter extends AbstractTurtleWriter {
 
             // sort order by predicate and object
             private Comparator<Node> predicateSort = Comparator.comparing(node ->
-                    graph.find(node, RDF.predicate.asNode(), Node.ANY).next().getObject().getURI() +
+                    graph.find(node, RDF.predicate.asNode(), Node.ANY).next().getObject() +
                             AIFComparableNode.getComparableString(graph,
                                     graph.find(node, RDF.object.asNode(), Node.ANY).next().getObject())
             );

--- a/java/src/main/resources/com/ncc/aif/restricted_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_aif.shacl
@@ -359,55 +359,6 @@ aida:InformativeJustificationMembersShape
 ##  the argument assertion.
 
 #------------------------
-
-# aida:SystemShape
-#     sh:sparql[
-#         sh:message "TA1, TA2, and TA3 must have exactly one informative mention for each aida:Entity, aida:Event, and aida:Relation prototype that is an object of an AIF argument assertion, for each document that provides a justification for the argument assertion.. See {$this}" ;
-#         sh:select """
-#         PREFIX aida:  <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology#>
-#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-#         SELECT ?this #(COUNT(DISTINCT ?mention) AS $value)
-#       	WHERE {
-#             ?this a ?prototye_type .
-#             OPTIONAL { ?this aida:informativeJustification ?mention } .
-    
-#             ?statement a ?statement_type .
-#             ?statement rdf:object ?this .
-    
-#             FILTER(?statement_type = rdf:Statement || ?statement_type = aida:ArgumentStatement)
-#             FILTER(?prototye_type = aida:Entity || ?prototye_type = aida:Event || ?prototye_type = aida:Relation)
-#       	}
-# 		GROUP BY ?this
-#         #HAVING (COUNT(DISTINCT ?mention) != 1 )
-#         """ ;
-#     ] .
-
-
-
-## TODO: This needs to be optimized
-# aida:EREOneInformativeJustificationMembers
-#     a sh:SPARQLConstraint ;
-#     sh:message "TA1, TA2, and TA3 must have exactly one informative mention for each aida:Entity, aida:Event, and aida:Relation prototype that is an object of an AIF argument assertion, for each document that provides a justification for the argument assertion. See {$this}" ;
-#     sh:select """
-#         PREFIX aida:  <https://raw.githubusercontent.com/NextCenturyCorporation/AIDA-Interchange-Format/master/java/src/main/resources/com/ncc/aif/ontologies/InterchangeOntology#>
-#         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-#         SELECT ?this (COUNT(DISTINCT ?mention) AS $value)
-#       	WHERE {
-#             ?this a ?prototye_type .
-#             OPTIONAL { ?this aida:informativeJustification ?mention } .
-    
-#             ?statement a ?statement_type .
-#             ?statement rdf:object ?this .
-    
-#             FILTER(?statement_type = rdf:Statement || ?statement_type = aida:ArgumentStatement)
-#             FILTER(?prototye_type = aida:Entity || ?prototye_type = aida:Event || ?prototye_type = aida:Relation)
-#       	}
-# 		GROUP BY ?this
-#         HAVING (COUNT(DISTINCT ?mention) < 1 )
-#     """ ;
-#     .
-
-
 aida:EREOneInformativeJustificationMembers
     a sh:SPARQLConstraint ;
     sh:message "TA1, TA2, and TA3 must have exactly one informative mention for each aida:Entity, aida:Event, and aida:Relation prototype that is an object of an AIF argument assertion, for each document that provides a justification for the argument assertion. See {$this}" ;
@@ -431,16 +382,25 @@ aida:EREOneInformativeJustificationMembers
     """ ;
     .
 
+# aida:EREOneInformativeJustificationMembersShape
+#     a sh:NodeShape ;
+#     sh:targetClass aida:Entity, aida:Event, aida:Relation ;
+#     sh:property [
+#         sh:path aida:prototype, aida:informativeJustification ;
+#         sh:sparql aida:EREOneInformativeJustificationMembers ;
+#     ]
+#     .
 
-aida:EREOneInformativeJustificationMembersShape
-    a sh:NodeShape ;
-    sh:targetClass aida:Entity, aida:Event, aida:Relation ;
+
+aida:ClusterShape
+   a sh:NodeShape ;
+   sh:targetClass aida:SameAsCluster ;
+
     sh:property [
-        sh:path aida:informativeJustification ;
+        sh:path aida:InformativeJustificationPropertyShape ;
         sh:sparql aida:EREOneInformativeJustificationMembers ;
     ]
-    .
-
+    . 
 #########################
 # 2.4.1
 # 18. Each justification span must have exactly one aida:source (containing the document element ID) and one aida:sourceDocument (containing the document ID).  

--- a/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
+++ b/java/src/main/resources/com/ncc/aif/restricted_claimframe_aif.shacl
@@ -231,13 +231,14 @@ aida:AssociatedKEsEntityPrototypeRequireHandle
     ];
 
     # sh:maxCount 1 is inherited from aida_ontology.shacl
-    sh:property [
-        a sh:PropertyShape ;
-        sh:path aida:handle ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:message "Entity prototype requires handle"
-    ] .
+    # sh:property [
+    #     a sh:PropertyShape ;
+    #     sh:path aida:handle ;
+    #     sh:minCount 1 ;
+    #     sh:maxCount 1 ;
+    #     sh:message "Entity prototype requires handle"
+    # ] 
+    .
 
 #------------------------
 

--- a/java/src/test/java/com/ncc/aif/NistExamplesAndValidationTest.java
+++ b/java/src/test/java/com/ncc/aif/NistExamplesAndValidationTest.java
@@ -69,9 +69,9 @@ public class NistExamplesAndValidationTest {
        ((Logger) org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.INFO);
        Set<String> ont = Set.of("com/ncc/aif/ontologies/LDCOntology");
        utils = new NistTestUtils(LDC_NS, ValidateAIF.create(ont, ValidateAIF.Restriction.NIST), DUMP_ALWAYS, DUMP_TO_FILE);
-       
-       //utils = new NistTestUtils(LDC_NS, ValidateAIF.createForDWD(ValidateAIF.Restriction.NIST), DUMP_ALWAYS,
-       //                                 DUMP_TO_FILE);
+
+       //TODO: Should we be using creatForDWD???? PLE- 20220616
+    //    utils = new NistTestUtils(LDC_NS, ValidateAIF.createForDWD(ValidateAIF.Restriction.NIST), DUMP_ALWAYS,DUMP_TO_FILE);
    }
  
    private Model model;
@@ -150,8 +150,7 @@ public class NistExamplesAndValidationTest {
                        null, 3);
                utils.expect(ShaclShapes.EdgeJustificationCompound, SH.ClassConstraintComponent,null, 2);
 
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-               //utils.testInvalid("NIST.invalid: CompoundJustification must be used only for justifications of argument assertions");
+               utils.testInvalid("NIST.invalid: CompoundJustification must be used only for justifications of argument assertions");
            }
  
            @Test
@@ -192,9 +191,8 @@ public class NistExamplesAndValidationTest {
  
                utils.expect(ShaclShapes.RelationArgumentShape, SH.SPARQLConstraintComponent, ShaclShapes.EdgeJustificationCount);
 
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-            //    utils.testInvalid("NIST.invalid: (More than two justifications in CompoundJustification) " +
-            //            "Exactly 1 or 2 contained justifications in a CompoundJustification required for an edge");
+               utils.testInvalid("NIST.invalid: (More than two justifications in CompoundJustification) " +
+                       "Exactly 1 or 2 contained justifications in a CompoundJustification required for an edge");
            }
  
            @Test
@@ -222,8 +220,7 @@ public class NistExamplesAndValidationTest {
  
                markJustification(eventEdge, compound);
  
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-               //utils.testValid("NIST.valid: CompoundJustification must be used only for justifications of argument assertions");
+               utils.testValid("NIST.valid: CompoundJustification must be used only for justifications of argument assertions");
            }
        }
  
@@ -257,8 +254,7 @@ public class NistExamplesAndValidationTest {
                utils.expect(ShaclShapes.EventArgumentShape, SH.SPARQLConstraintComponent, ShaclShapes.EdgeJustificationCount);
                utils.expect(ShaclShapes.RelationArgumentShape, SH.SPARQLConstraintComponent, ShaclShapes.EdgeJustificationCount);
 
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-               //utils.testInvalid("NIST.invalid: edge justification contains one or two mentions (three is too many)");
+               utils.testInvalid("NIST.invalid: edge justification contains one or two mentions (three is too many)");
            }
  
  
@@ -284,8 +280,7 @@ public class NistExamplesAndValidationTest {
                utils.expect(ShaclShapes.RelationArgumentShape, SH.SPARQLConstraintComponent, ShaclShapes.EdgeJustificationCount);
                utils.expect(ShaclShapes.CompoundJustificationMinimum, SH.MinCountConstraintComponent, null);
 
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-               //utils.testInvalid("NIST.invalid: edge justification contains one or two mentions (zero is not enough)");
+               utils.testInvalid("NIST.invalid: edge justification contains one or two mentions (zero is not enough)");
            }
  
            @Test
@@ -310,8 +305,7 @@ public class NistExamplesAndValidationTest {
                        entity, system, 1.0);
                markJustification(eventEdge, compound);
  
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-               //utils.testValid("NIST.valid: edge justification contains two mentions (i.e., one or two are valid)");
+               utils.testValid("NIST.valid: edge justification contains two mentions (i.e., one or two are valid)");
            }
  
            @Test
@@ -334,8 +328,7 @@ public class NistExamplesAndValidationTest {
                        entity, system, 1.0);
                markJustification(eventEdge, compound);
  
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-               //utils.testValid("NIST.valid: edge justification contains one mention (i.e., one or two are valid)");
+               utils.testValid("NIST.valid: edge justification contains one mention (i.e., one or two are valid)");
            }
        }
  
@@ -920,9 +913,8 @@ public class NistExamplesAndValidationTest {
                utils.expect(ShaclShapes.ClusterMembersShape,
                        SH.SPARQLConstraintComponent,
                        ShaclShapes.ClusterMembersSameAsBaseClass);
-                //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-            //    utils.testInvalid("HomogeneousClusters.invalid (event exists in relation cluster): Clusters must be " +
-                    //    "homogeneous by base class (Entity, Event, or Relation).");
+               utils.testInvalid("HomogeneousClusters.invalid (event exists in relation cluster): Clusters must be " +
+                       "homogeneous by base class (Entity, Event, or Relation).");
            }
  
            @Test
@@ -936,9 +928,8 @@ public class NistExamplesAndValidationTest {
                //add valid relation cluster member to relation cluster
                markAsPossibleClusterMember(model, relationMember, relationCluster, 1.0, system);
  
-               //TODO: Fix Tests cause by aida:EREOneInformativeJustificationMembers
-            //    utils.testValid("HomogeneousClusters.valid: Clusters must be homogeneous by base class " +
-            //            "(Entity, Event, or Relation)");
+               utils.testValid("HomogeneousClusters.valid: Clusters must be homogeneous by base class " +
+                       "(Entity, Event, or Relation)");
            }
        }
  

--- a/java/src/test/java/com/ncc/aif/NistTA3ExamplesAndValidationTest.java
+++ b/java/src/test/java/com/ncc/aif/NistTA3ExamplesAndValidationTest.java
@@ -9,6 +9,7 @@ import static com.ncc.aif.AIFUtils.makeSystemWithURI;
 import static com.ncc.aif.AIFUtils.makeTextJustification;
 import static com.ncc.aif.AIFUtils.markAsArgument;
 import static com.ncc.aif.AIFUtils.markAsPossibleClusterMember;
+import static com.ncc.aif.AIFUtils.markAttribute;
 import static com.ncc.aif.AIFUtils.markCompoundJustification;
 import static com.ncc.aif.AIFUtils.markConfidence;
 import static com.ncc.aif.AIFUtils.markEdgesAsMutuallyExclusive;
@@ -138,30 +139,133 @@ public class NistTA3ExamplesAndValidationTest {
                                 @BeforeEach
                                 void setup() {
 
-                                        validProtoType1 = makeEntity(model, utils.getUri("someTestURI1"), system);
-                                        markHandle(validProtoType1, "ClusterID1");
+                                        ImmutablePair<Resource, Resource> aPair = utils.makeValidNistEntity(
+                                                LDCOntology.PER);
 
-                                        validProtoType2 = makeEntity(model, utils.getUri("someTestURI2"), system);
-                                        markHandle(validProtoType2, "ClusterID2");
+                                        markHandle(aPair.getKey(), "SomeBasicCluster1");
 
-                                        validProtoType3 = makeEntity(model, utils.getUri("someTestURI3"), system);
-                                        markHandle(validProtoType3, "ClusterID3");
+                                        Resource entityCluster1 = aPair.getValue();
+                                        Resource entityCluster2 = aPair.getValue();
+                                        Resource entityCluster3 = aPair.getValue();
+
+                                        ////////////////////////////////////////////////////////////////////////////
+                                        String Entity1Uri = utils.getEntityUri();
+                                        String Event1Uri = utils.getEventUri();
+
+                                        final Resource validProtoTypeEvent1 = makeEvent(model, Event1Uri, system);
+                                        markType(model, utils.getAssertionUri(), validProtoTypeEvent1, SeedlingOntology.Personnel_Elect, system, 1.0);
+                
+                                        final Resource validProtoTypeEntity1 = makeEntity(model, Entity1Uri, system);
+                                        markType(model, utils.getAssertionUri(), validProtoTypeEntity1, SeedlingOntology.Person, system, 1.0);
+                                        markHandle(validProtoTypeEntity1, "EntityClusterID1");
+
+
+                                        markAsPossibleClusterMember(model, validProtoTypeEntity1, entityCluster1, .75, system);
+
+                                        //PREDICATE AS String
+                                        final Resource argument1 = markAsArgument(model, validProtoTypeEvent1, "A1_ppt_thing_bought",
+                                                validProtoTypeEntity1, system, 0.785, utils.getUri("eventArgument-1"));
+                                        //PREDICATE AS URI
+                                        // final Resource argument1 = markAsArgument(model, validProtoTypeEvent1, SeedlingOntology.Personnel_Elect_Elect,
+                                        // validProtoTypeEntity1, system, 0.785, utils.getUri("eventArgument-1"));
+
+                                        final Resource typeAssertion1 = markType(model, utils.getAssertionUri(), validProtoTypeEvent1,
+                                        SeedlingOntology.Personnel_Elect_Elect, system, 1.0);
+                                        final Resource justification1 = markTextJustification(model, typeAssertion1, "HC00002Z0", 0, 10,
+                                        system, 1d);
+
+                                        markInformativeJustification(validProtoTypeEvent1, justification1);
+                                        markInformativeJustification(validProtoTypeEntity1, justification1);
+
+                                        addSourceDocumentToJustification(justification1, "HC00002Z0");
+                
+                                        markAttribute(argument1, InterchangeOntology.Negated);
+                                        markAttribute(argument1, InterchangeOntology.Hedged);
+
+                                        ////////////////////////////////////////////////////////////////////////////
+                                        String Entity2Uri = utils.getEntityUri();
+                                        String Event2Uri = utils.getEventUri();
+
+                                        final Resource validProtoTypeEvent2 = makeEvent(model, Event2Uri, system);
+                                        markType(model, utils.getAssertionUri(), validProtoTypeEvent2, SeedlingOntology.Personnel_Elect, system, 1.0);
+                
+                                        final Resource validProtoTypeEntity2 = makeEntity(model, Entity2Uri, system);
+                                        markType(model, utils.getAssertionUri(), validProtoTypeEntity2, SeedlingOntology.Person, system, 1.0);
+                                        markHandle(validProtoTypeEntity2, "EntityClusterID2");
+
+
+                                        markAsPossibleClusterMember(model, validProtoTypeEntity2, entityCluster2, .75, system);
+
+                                        //PREDICATE AS String
+                                        final Resource argument2 = markAsArgument(model, validProtoTypeEvent2, "A1_ppt_thing_bought",
+                                                validProtoTypeEntity2, system, 0.785, utils.getUri("eventArgument-2"));
+                                        //PREDICATE AS URI
+                                        // final Resource argument2 = markAsArgument(model, validProtoTypeEvent2, SeedlingOntology.Personnel_Elect_Elect,
+                                        // validProtoTypeEntity2, system, 0.785, utils.getUri("eventArgument-2"));
+
+                                        final Resource typeAssertion2 = markType(model, utils.getAssertionUri(), validProtoTypeEvent2,
+                                        SeedlingOntology.Personnel_Elect_Elect, system, 1.0);
+                                        final Resource justification2 = markTextJustification(model, typeAssertion2, "HC00002Z0", 0, 10,
+                                        system, 1d);
+
+                                        markInformativeJustification(validProtoTypeEvent2, justification2);
+                                        markInformativeJustification(validProtoTypeEntity2, justification2);
+
+                                        addSourceDocumentToJustification(justification2, "HC00002Z0");
+                
+                                        markAttribute(argument2, InterchangeOntology.Negated);
+                                        markAttribute(argument2, InterchangeOntology.Hedged);
+
+                                        ////////////////////////////////////////////////////////////////////////////
+                                        String Entity3Uri = utils.getEntityUri();
+                                        String Event3Uri = utils.getEventUri();
+
+                                        final Resource validProtoTypeEvent3 = makeEvent(model, Event3Uri, system);
+                                        markType(model, utils.getAssertionUri(), validProtoTypeEvent3, SeedlingOntology.Personnel_Elect, system, 1.0);
+                
+                                        final Resource validProtoTypeEntity3 = makeEntity(model, Entity3Uri, system);
+                                        markType(model, utils.getAssertionUri(), validProtoTypeEntity3, SeedlingOntology.Person, system, 1.0);
+                                        markHandle(validProtoTypeEntity3, "EntityClusterID3");
+
+                                        markAsPossibleClusterMember(model, validProtoTypeEntity3, entityCluster3, .75, system);
+
+                                        //PREDICATE AS String
+                                        final Resource argument3 = markAsArgument(model, validProtoTypeEvent3, "A1_ppt_thing_bought",
+                                                validProtoTypeEntity3, system, 0.785, utils.getUri("eventArgument-3"));
+                                        //PREDICATE AS URI
+                                        // final Resource argument3 = markAsArgument(model, validProtoTypeEvent3, SeedlingOntology.Personnel_Elect_Elect,
+                                        // validProtoTypeEntity3, system, 0.785, utils.getUri("eventArgument-3"));
+
+                                        final Resource typeAssertion3 = markType(model, utils.getAssertionUri(), validProtoTypeEvent3,
+                                        SeedlingOntology.Personnel_Elect_Elect, system, 1.0);
+                                        final Resource justification3 = markTextJustification(model, typeAssertion3, "YY00002Z0", 0, 10,
+                                        system, 1d);
+
+                                        markInformativeJustification(validProtoTypeEvent3, justification3);   
+                                        markInformativeJustification(validProtoTypeEntity3, justification3);
+
+                                        addSourceDocumentToJustification(justification3, "YY00002Z0");
+
+                                        markAttribute(argument3, InterchangeOntology.Negated);
+                                        markAttribute(argument3, InterchangeOntology.Hedged);
+
 
                                         validSameAsCluster1 = AIFUtils
                                                         .makeAIFResource(model,
                                                                         "http://www.caci.com/cluster/SameAsCluster/ClusterID1",
                                                                         InterchangeOntology.SameAsCluster, system)
-                                                        .addProperty(InterchangeOntology.prototype, validProtoType1);
+                                                        .addProperty(InterchangeOntology.prototype, validProtoTypeEvent1);
+                                        
                                         validSameAsCluster2 = AIFUtils
                                                         .makeAIFResource(model,
                                                                         "http://www.caci.com/cluster/SameAsCluster/ClusterID2",
                                                                         InterchangeOntology.SameAsCluster, system)
-                                                        .addProperty(InterchangeOntology.prototype, validProtoType2);
+                                                        .addProperty(InterchangeOntology.prototype, validProtoTypeEvent2);
                                         validSameAsCluster3 = AIFUtils
                                                         .makeAIFResource(model,
                                                                         "http://www.caci.com/cluster/SameAsCluster/ClusterID3",
                                                                         InterchangeOntology.SameAsCluster, system)
-                                                        .addProperty(InterchangeOntology.prototype, validProtoType3);
+                                                        .addProperty(InterchangeOntology.prototype, validProtoTypeEvent3);
 
                                         validComponentKE = validSameAsCluster1;
 
@@ -225,8 +329,7 @@ public class NistTA3ExamplesAndValidationTest {
                                 @Test
                                 void validMinimal() {
                                         validClaim.addToModel(model, utils.getUri("a_minimal_claimframe"), system);
-                                        //TODO: FIX TestUtils.java (triples are typed to a resource)
-                                        //utils.testValid("Create minimal valid claim frame");
+                                        utils.testValid("Create minimal valid claim frame");
                                 }
 
                                 @Test
@@ -255,9 +358,7 @@ public class NistTA3ExamplesAndValidationTest {
                                                         system));
 
                                         validClaim.addToModel(model, utils.getUri("a_full_claimframe"), system);
-
-                                        //TODO: FIX TestUtils.java (triples are typed to a resource)
-                                        //utils.testValid("Create full valid claim frame"); 
+                                        utils.testValid("Create full valid claim frame"); 
                                 }
 
                                 // Test Claim requires exactly 1 claimId
@@ -267,9 +368,7 @@ public class NistTA3ExamplesAndValidationTest {
                                         validClaim.setClaimId(null);
                                         validClaim.addToModel(model, utils.getUri("a_missing_claim_id"), system);
                                         utils.expect(null, SH.MinCountConstraintComponent, null);
-
-                                        //TODO: FIX TestUtils.java (triples are typed to a resource)
-                                        //utils.testInvalid("ClaimTest.invalid (missing id): Claim must have an id");
+                                        utils.testInvalid("ClaimTest.invalid (missing id): Claim must have an id");
 
                                 }
 
@@ -280,8 +379,7 @@ public class NistTA3ExamplesAndValidationTest {
                                         validClaim.setXVariable(Collections.emptySet()).addToModel(model,
                                                         utils.getUri("claim"), system);
                                         utils.expect(null, SH.MinCountConstraintComponent, null);
-                                        //TODO: FIX TestUtils.java (triples are typed to a resource)
-                                        //utils.testInvalid("ClaimTest.invalid (missing x variable): Claim must have X Variable");
+                                        utils.testInvalid("ClaimTest.invalid (missing x variable): Claim must have X Variable");
                                 }
 
                                 @Test
@@ -293,8 +391,7 @@ public class NistTA3ExamplesAndValidationTest {
                                         validClaim.addToModel(model, utils.getUri("too_many_claimer_affiliation"),
                                                         system);
                                         utils.expect(null, SH.MaxCountConstraintComponent, null);
-                                        //TODO: FIX TestUtils.java (triples are typed to a resource)
-                                        //utils.testInvalid("ClaimTest.invalid (too many claimer affiliation): Claim must have X Variable");
+                                        utils.testInvalid("ClaimTest.invalid (too many claimer affiliation): Claim can have at most 3 aida:claimerAffiliation");
                                 }
 
                                 // Test ClaimComponent too many types
@@ -325,8 +422,7 @@ public class NistTA3ExamplesAndValidationTest {
                                         validClaim.addToModel(model, utils.getUri("too_many_claimcomponents"), system);
                                         utils.expect(null, SH.MaxCountConstraintComponent, null);
 
-                                        //TODO: FIX TestUtils.java (triples are typed to a resource)
-                                        //utils.testInvalid("ClaimComponent.invalid (Too many type): ClaimComponent must max 5 types");
+                                        utils.testInvalid("ClaimComponent.invalid (Too many type): ClaimComponent must max 5 types");
 
                                 }
 


### PR DESCRIPTION
* Upgraded com.fasterxml.jackson.* to version 2.10.0 (latest)

Updated both java and python AIF versions to 1.0.5

Updated all documentation to reference AIF 1.0.5

* Aida 1355: Merge AIF develop into master (#277)

* AIDA-1074: Bump to 1.1.0-SNAPSHOT

* Upgraded com.fasterxml.jackson.* to version 2.10.0 (latest)

Updated all documentation that referenced version 1.0.4 to use version 1.0.5

* Reverted change to FAQ.md

* Remove upgrading from Kotlin section in FAQ.md

* Aida 525: Update AIF to Java 11 (#268)

* POM updates for JDK12
* Upgraded libs to current/compatible versions
* Switch to Java 11 because it has long-term support (LTS)

* AIDA-1140: Examples of hypotheses in annotations.
Added methods to create hypotheses separately from normal AIF.
Created way to validate union of hypothesis and normal AIF.
Exposed more methods in TestUtils for tests to use.

* PR #269: address @nextcen-dgemoets comments.
Move hypothesis testing to TestUtils.
Revert TestUtils methods to be private.

* PR #269: Remove unnecessary validator accessor.

* Aida 1158 (#270)

Created new hypothesis-max-size command line argument that controls the maximum size a hypothesis file can be for validation

Set the default value to 5 for 5MB on the hypothesis-max-size argument

* Aida 1287 (#271)

Updated README.md to include:
* missing configuration definitions implemented during M18 evaluation
* missing documentation about deploying Batch Single containers on a custom AMI within AWS Batch
* info that the region is a AWS specific thing
* missing configurations for batch-single

* Aida 1242 (#272)

* Added initial debugging and command-line switch

* Suppress hundreds of thousands of Jena LockMRSW lock messages

* Only modify the ThreadedValidationEngine logger

* Moved logging of completed constraints to the thread that completed it.

* Use parameterized debug messages; log resource info

* Add debug toggle to ValidateAIF API; tweaked filtered node logging.

* AIDA-1309 (#273)

* Upgrade to SHACL v1.3.2-SNAPSHOT and incorporate ECurley update SPARQL query

* Fix SHACL version to 1.3.2-SNAPSHOT

* Reverted to SHACL v1.2.1 and added clusterPrototypeMissingTypeAssertion() test

* Removed clusterPrototypeMissingTypeAssertion() because entityMissingType() sufficiently covers it.

* Removed extra space so that this file isn't touched in AIDA-1309.

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

* Upgraded to SHACL 1.3.2 (#274)

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

* Bump version to v1.1.0

* Incorporated conflicts from develop into tree

* Documented Java 11 requirement (#276)

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

Co-authored-by: Craig Warsaw <craig.warsaw@nextcentury.com>
Co-authored-by: Craig Warsaw <craigwarsaw@users.noreply.github.com>
Co-authored-by: Patrick Sharkey <patrick.sharkey@nextcentury.com>
Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>
Co-authored-by: ecurley <eddie.curley@nextcentury.com>
Co-authored-by: sharknc <44296239+sharknc@users.noreply.github.com>

* V1.2.0 rc (#296)

* AIDA-1074: Bump to 1.1.0-SNAPSHOT

* Upgraded com.fasterxml.jackson.* to version 2.10.0 (latest)

Updated all documentation that referenced version 1.0.4 to use version 1.0.5

* Reverted change to FAQ.md

* Remove upgrading from Kotlin section in FAQ.md

* Aida 525: Update AIF to Java 11 (#268)

* POM updates for JDK12
* Upgraded libs to current/compatible versions
* Switch to Java 11 because it has long-term support (LTS)

* AIDA-1140: Examples of hypotheses in annotations.
Added methods to create hypotheses separately from normal AIF.
Created way to validate union of hypothesis and normal AIF.
Exposed more methods in TestUtils for tests to use.

* PR #269: address @nextcen-dgemoets comments.
Move hypothesis testing to TestUtils.
Revert TestUtils methods to be private.

* PR #269: Remove unnecessary validator accessor.

* Aida 1158 (#270)

Created new hypothesis-max-size command line argument that controls the maximum size a hypothesis file can be for validation

Set the default value to 5 for 5MB on the hypothesis-max-size argument

* Aida 1287 (#271)

Updated README.md to include:
* missing configuration definitions implemented during M18 evaluation
* missing documentation about deploying Batch Single containers on a custom AMI within AWS Batch
* info that the region is a AWS specific thing
* missing configurations for batch-single

* Aida 1242 (#272)

* Added initial debugging and command-line switch

* Suppress hundreds of thousands of Jena LockMRSW lock messages

* Only modify the ThreadedValidationEngine logger

* Moved logging of completed constraints to the thread that completed it.

* Use parameterized debug messages; log resource info

* Add debug toggle to ValidateAIF API; tweaked filtered node logging.

* AIDA-1309 (#273)

* Upgrade to SHACL v1.3.2-SNAPSHOT and incorporate ECurley update SPARQL query

* Fix SHACL version to 1.3.2-SNAPSHOT

* Reverted to SHACL v1.2.1 and added clusterPrototypeMissingTypeAssertion() test

* Removed clusterPrototypeMissingTypeAssertion() because entityMissingType() sufficiently covers it.

* Removed extra space so that this file isn't touched in AIDA-1309.

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

* Upgraded to SHACL 1.3.2 (#274)

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

* Bump version to v1.1.0

* Documented Java 11 requirement (#276)

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

* AIDA-1354b: Bumped develop to v1.1.1-SNAPSHOT (#278)

* Bumped develop to v1.1.1-SNAPSHOT

* Added .dev1 to the end ofthe python version, as per @ecurley suggestion

Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>

* AIDA-1372: Add example to generate LDCTime ranges (#279)

* AIDA-1372: Add example to generate LDCTime ranges

* add java range API and fix example

* resolve review comments

* AIDA-1459: Initial commit standalone AIF validator container image

* Address review comments

* Add optional uri_ref argument to link_to_external_kb (#283)

Co-authored-by: Roger Bock <roger@bbn.com>

* AIDA-1480: Add VideoJustification (#282)

* AIDA-1480: Add VideoJustification.
Update InterchangeOntology with new justification classes and property.
Update OntologyGeneration to create properties as well as classes.
Replaced AidaAnnotationOntology.java with InterchangeOntology.java.
Updated all generated ontology .java files.

* AIDA-1480: Add VideoJustification.
Update InterchangeOntology with new justification classes and property.
Update OntologyGeneration to create properties as well as classes.
Replaced AidaAnnotationOntology.java with InterchangeOntology.java.
Updated all generated ontology .java files.

* AIDA-1480: Add VideoJustification API.
Add AIFUtils.makeVideoJustification() APIs.
Add VideoJustificationShape to aida_ontology.shacl.
Add tests to ExamplesAndValidationTest.

* AIDA-1481: M36 SameAsCluster changes (#284)

* AIDA-1480: Add VideoJustification.
Update InterchangeOntology with new justification classes and property.
Update OntologyGeneration to create properties as well as classes.
Replaced AidaAnnotationOntology.java with InterchangeOntology.java.
Updated all generated ontology .java files.

* AIDA-1480: Add VideoJustification.
Update InterchangeOntology with new justification classes and property.
Update OntologyGeneration to create properties as well as classes.
Replaced AidaAnnotationOntology.java with InterchangeOntology.java.
Updated all generated ontology .java files.

* AIDA-1480: Add VideoJustification API.
Add AIFUtils.makeVideoJustification() APIs.
Add VideoJustificationShape to aida_ontology.shacl.
Add tests to ExamplesAndValidationTest.

* AIDA-1481: M36 SameAsCluster changes.
Expand handle to be used on EREs.
Modify AIFUtils.makeCluster... to conditionally add prototype as member.
Add prototype restrictions to restricted_aif.
Add prototype tests.
Modify NIST tests to handle prototype restrictions.

* AIDA-1481: Prevent handle on cluster

* AIDA-1497: Move importance from cluster to prototype (#285)

* AIDA-1480: Add VideoJustification.
Update InterchangeOntology with new justification classes and property.
Update OntologyGeneration to create properties as well as classes.
Replaced AidaAnnotationOntology.java with InterchangeOntology.java.
Updated all generated ontology .java files.

* AIDA-1480: Add VideoJustification.
Update InterchangeOntology with new justification classes and property.
Update OntologyGeneration to create properties as well as classes.
Replaced AidaAnnotationOntology.java with InterchangeOntology.java.
Updated all generated ontology .java files.

* AIDA-1480: Add VideoJustification API.
Add AIFUtils.makeVideoJustification() APIs.
Add VideoJustificationShape to aida_ontology.shacl.
Add tests to ExamplesAndValidationTest.

* AIDA-1481: M36 SameAsCluster changes.
Expand handle to be used on EREs.
Modify AIFUtils.makeCluster... to conditionally add prototype as member.
Add prototype restrictions to restricted_aif.
Add prototype tests.
Modify NIST tests to handle prototype restrictions.

* AIDA-1481: Prevent handle on cluster

* AIDA-1497: Move importance to prototype

* AIDA-1497: Test prototype not member of cluster

* AIDA-1497: Make aida:channel optional

* AIDA-1497: Add first cut of M36 ontologies

* AIDA-1513: Changes for 1.2-SNAPSHOT. (#286)

Fix M36 ontology problems (spaces).
Add environment variable to use M36 ontology instead of M18.

* AIDA-1515: Fix reference to M36 Ontology for 1.2-SNAPSHOT (#287)

* AIDA-1515: Fix reference to M36 ontology

* AIDA-1515: fix typo

* AIDA-1529: Fix error with LDC column header (#289)

admin push for quicker turn-around

* AIDA-1492/1514: Python support for VideoJustification + better shacl names (#288)

* AIDA-1492: OntologyGeneration produce py constants.
Fix python tests to work with new constants

* AIDA-1492: Add VideoJustificaiton to python

* AIDA-1514: Better shacl names + fix typo

* PR #288: Address PR comments

* PR #288: Reference java installation README

* AIDA-1518: Changes required for eval plan v1.1 (#290)

* AIDA-1518: Support LDCTime for M36.
Add NistExamplesAndValidationTest.Time.
Add restricted_aif.shacl:LDCTimeShape.
Fix TTL super class for LDCOntologyM36.
Made LDCTimeComponent.makeAIFTimeComponent public.

* AIDA-1518: Remove type/justification requirements

* AIDA-1518: Disable type requirement tests

* AIDA-1518: Performance
Add InstrumentedValidationEngine log constraint times.
Add logback.xml to write performance logs to file.
Reduced node collection time for Event/Relation argument shapes.
Updated tests to reflect constraint changes.

* AIDA-1518: --debug controls performance logging

* AIDA-1518: Order test output.
Prevent InformativeJustification on cluster

* AIDA-1518: Add endlines

* AIDA-1374: Add time range for python (#291)

* AIDA-1374: Add time range for python

* AIDA-1536: Fix LDC typo

* AIDA-1536: undo TopicFIller change.

* AIDA-1374: Exclude 0 from confidence range

* AIDA-1542: Hotfixes for M36 develop.
Change MHI to have hasText.
Move ontologies to github locations.
Add init.py to rdf_ontologies (#293)

* AIDA-1543: Move cluster member class restriction. (#294)

Moved and renamed HypothesisClusterMembersShape.
Updated tests to account for move.
Updated tests to reflect ontology move.

* AIDA-865: Add release profile (#292)

* AIDA-1455: Make M36 LDC default and fix version. (#295)

* AIDA-1455: Make M36 LDC default.
Change validator --ldc flag to use M36.
Change aif docker to have USE_M18_ONTOLOGY flag.
Update SeedlingOntology to use github.
Fix tests to use M18 ontology.
Remove last of tac.nist addresses.

* AIDA-1455: Update version to 1.2.0-SNAPSHOT

* AIDA-1455: Update python version

* Change versions to 1.2.0 and correct dependency

* Modify py_validator.sh to use docker validation.

* Version 1.2.1 + virtualenv to py README.md

* PR #296: Add endlines, update README versions

Co-authored-by: Craig Warsaw <craig.warsaw@nextcentury.com>
Co-authored-by: Craig Warsaw <craigwarsaw@users.noreply.github.com>
Co-authored-by: Patrick Sharkey <patrick.sharkey@nextcentury.com>
Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>
Co-authored-by: sharknc <44296239+sharknc@users.noreply.github.com>
Co-authored-by: nextcen-dgemoets <darren.gemoets@caci.com>
Co-authored-by: rogerbock <7094871+rogerbock@users.noreply.github.com>
Co-authored-by: Roger Bock <roger@bbn.com>

* AIDA-1617: Remove CanHaveName from non-name types (#298)

* AIDA-1617: Remove CanHaveName from non-name types

* AIDA-1617: Remove prototype restriction for NIST.

* added .ds_store to git ignore

* Aida 2054 - Valid predicates for Event/Relation (#316) (#317)

* stash

* using python to parse json

* pulling args

* created oneof list and ontology

* added files, cleaned testing

* removed commented code

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

Co-authored-by: phile-caci <62263242+phile-caci@users.noreply.github.com>
Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Develop (#319)

* Aida 2054 - Valid predicates for Event/Relation (#316)

* stash

* using python to parse json

* pulling args

* created oneof list and ontology

* added files, cleaned testing

* removed commented code

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Update Dockerfile

Revert FROM maven:3.8.3-jdk-11 to FROM maven:3.8.1-jdk-11
Permission Issue with Docker on Jenkins CentOS

* Update Dockerfile

Removed unused $HOME variable

* adjusted shacl with switches (#318)

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Develop (#322)

* Aida 2054 - Valid predicates for Event/Relation (#316)

* stash

* using python to parse json

* pulling args

* created oneof list and ontology

* added files, cleaned testing

* removed commented code

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Update Dockerfile

Revert FROM maven:3.8.3-jdk-11 to FROM maven:3.8.1-jdk-11
Permission Issue with Docker on Jenkins CentOS

* Update Dockerfile

Removed unused $HOME variable

* adjusted shacl with switches (#318)

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#320)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#321)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* maven docker update ahs removed Python3

* added Python3 to docker

* added Python3 to docker

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Develop (#325)

* Aida 2054 - Valid predicates for Event/Relation (#316)

* stash

* using python to parse json

* pulling args

* created oneof list and ontology

* added files, cleaned testing

* removed commented code

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Update Dockerfile

Revert FROM maven:3.8.3-jdk-11 to FROM maven:3.8.1-jdk-11
Permission Issue with Docker on Jenkins CentOS

* Update Dockerfile

Removed unused $HOME variable

* adjusted shacl with switches (#318)

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#320)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#321)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* maven docker update ahs removed Python3

* added Python3 to docker

* added Python3 to docker

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Changed AIF to use memory model as default instead of disk model (#323)

* Aida 2081 (#324)

* error in variable name in SHACL

* incorrect <=

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

Co-authored-by: Phi Le <ple@hq.nextcentury.com>
Co-authored-by: omitz <woleomit@gmail.com>

* Develop Push to Master (#327)

* Aida 2054 - Valid predicates for Event/Relation (#316)

* stash

* using python to parse json

* pulling args

* created oneof list and ontology

* added files, cleaned testing

* removed commented code

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Update Dockerfile

Revert FROM maven:3.8.3-jdk-11 to FROM maven:3.8.1-jdk-11
Permission Issue with Docker on Jenkins CentOS

* Update Dockerfile

Removed unused $HOME variable

* adjusted shacl with switches (#318)

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#320)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#321)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* maven docker update ahs removed Python3

* added Python3 to docker

* added Python3 to docker

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Changed AIF to use memory model as default instead of disk model (#323)

* Aida 2081 (#324)

* error in variable name in SHACL

* incorrect <=

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2078 (#326)

* validate subdirectories.

* Removed unnecessary comments.

* merge develop, remove claimframe tests

* removed claimframe test

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

Co-authored-by: Phi Le <ple@hq.nextcentury.com>
Co-authored-by: omitz <woleomit@gmail.com>

* Develop push to Master (#330)

* Aida 2054 - Valid predicates for Event/Relation (#316)

* stash

* using python to parse json

* pulling args

* created oneof list and ontology

* added files, cleaned testing

* removed commented code

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Update Dockerfile

Revert FROM maven:3.8.3-jdk-11 to FROM maven:3.8.1-jdk-11
Permission Issue with Docker on Jenkins CentOS

* Update Dockerfile

Removed unused $HOME variable

* adjusted shacl with switches (#318)

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#320)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2070 (#321)

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* Per Hoa:NIST does not prohibit a prototype E/R/E from being a member of two clusters (but the E/R/E must be the prototype of only one cluster). Uncertainty in cluster membership is allowed, and an E/R/E that is the prototype of cluster1 can be a member of cluster1 (with very high membership confidence) while also being a member of cluster2 (with very low membership confidence).

* maven docker update ahs removed Python3

* added Python3 to docker

* added Python3 to docker

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Changed AIF to use memory model as default instead of disk model (#323)

* Aida 2081 (#324)

* error in variable name in SHACL

* incorrect <=

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2078 (#326)

* validate subdirectories.

* Removed unnecessary comments.

* merge develop, remove claimframe tests

* removed claimframe test

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* Aida 2084 - informative mention on prototype check (#328)

* updates to nist ta3 restrictions

* new nist restriction implementation

* disabled test due to aida:EREOneInformativeJustificationMembers

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

* removed '?statement aida:confidence ?confidence .' (#329)

Co-authored-by: Phi Le <ple@hq.nextcentury.com>

Co-authored-by: Phi Le <ple@hq.nextcentury.com>
Co-authored-by: omitz <woleomit@gmail.com>

* setup use case for predicate as string

* switched claimfram valid test case from entity to event to showcase error

* Allow predicate to be a string instead of a URI.

* updated test model to match new SHACL

* updates to aida:EREOneInformativeJustificationMembers'

Co-authored-by: Craig Warsaw <craigwarsaw@users.noreply.github.com>
Co-authored-by: Patrick Sharkey <patrick.sharkey@nextcentury.com>
Co-authored-by: nextcen-dgemoets <darren.gemoets@caci.com>
Co-authored-by: Craig Warsaw <craig.warsaw@nextcentury.com>
Co-authored-by: nextcen-dgemoets <darren.gemoets@nextcentury.com>
Co-authored-by: ecurley <eddie.curley@nextcentury.com>
Co-authored-by: sharknc <44296239+sharknc@users.noreply.github.com>
Co-authored-by: rogerbock <7094871+rogerbock@users.noreply.github.com>
Co-authored-by: Roger Bock <roger@bbn.com>
Co-authored-by: phile-caci <62263242+phile-caci@users.noreply.github.com>
Co-authored-by: Phi Le <ple@hq.nextcentury.com>